### PR TITLE
chore: fix test setup to match parent repository configuration

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,3 +3,8 @@ bun = "latest"
 
 [env]
 _.path = ["./node_modules/.bin"]
+TEST_PG_USERNAME = "postgres"
+TEST_PG_PASSWORD = "postgres"
+TEST_PG_DATABASE = "test"
+TEST_PG_HOST = "localhost"
+TEST_PG_PORT = "5432"

--- a/README.md
+++ b/README.md
@@ -36,15 +36,37 @@ All packages require:
 
 ## Development
 
+### Prerequisites
+
+- Bun
+- Docker (for running tests with PostgreSQL)
+
+### Setup
+
 ```bash
 # Install dependencies
 bun install
+```
 
+### Running Tests
+
+The test suite includes both in-memory and PostgreSQL tests. To run tests:
+
+1. Start the PostgreSQL database:
+```bash
+docker-compose up -d
+```
+
+2. Run tests with environment variables:
+```bash
+TEST_PG_USERNAME=postgres TEST_PG_PASSWORD=postgres TEST_PG_DATABASE=test TEST_PG_HOST=localhost TEST_PG_PORT=5432 bun run test
+```
+
+### Other Commands
+
+```bash
 # Build all packages
 bun run build
-
-# Run tests
-bun run test
 
 # Lint code
 bun run lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:17.6-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: test
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 1s
+      timeout: 3s
+      retries: 5

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -20,8 +20,6 @@
   ],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc || true",
-    "test": "bun test",
-    "test:watch": "bun test --watch",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -20,8 +20,6 @@
   ],
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc || true",
-    "test": "bun test",
-    "test:watch": "bun test --watch",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,14 @@
       "dependsOn": ["check", "^lint"]
     },
     "test": {
-      "dependsOn": ["^test", "lint"]
+      "dependsOn": ["^test", "lint"],
+      "env": [
+        "TEST_PG_USERNAME",
+        "TEST_PG_PASSWORD",
+        "TEST_PG_DATABASE",
+        "TEST_PG_HOST",
+        "TEST_PG_PORT"
+      ]
     },
     "publish:package": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Summary
- Configure PostgreSQL test environment to match parent MyRound repository setup
- Tests now run successfully with proper database configuration
- Added mise environment variable management

## Changes
- 🐳 Add `docker-compose.yml` for local PostgreSQL test database
- 🔧 Configure TEST_PG environment variables in `.mise.toml`
- 📝 Add TEST_PG env vars to `turbo.json` for test task passthrough  
- 🧹 Remove test scripts from packages without test files (projections, aggregates)
- 📚 Update README with clear test running instructions

## Test Plan
✅ Start PostgreSQL: `docker-compose up -d`
✅ Run tests: `bun run test` or `mise exec -- bun run test`
✅ All 72 tests pass (54 in-memory + 18 PostgreSQL tests)