### PR TITLE
feat: add guardrail checks to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   ci:
@@ -77,3 +77,13 @@ jobs:
           TEST_PG_HOST: localhost
           TEST_PG_PORT: 5432
 
+      - name: Check architecture boundaries
+        run: bun run arch:check
+
+      - name: Check for unused dependencies
+        run: bun run deps:check
+
+      - name: Check for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds all guardrail checks to CI workflow to ensure they run on every PR
- These checks were set up locally but weren't being enforced in CI

## Changes
- ✅ Architecture boundary checking with `dependency-cruiser`
- ✅ Unused dependency detection with `depcheck`  
- ✅ Secret scanning with `gitleaks-action`

## Test Plan
- [ ] CI workflow runs successfully
- [ ] Architecture check completes (warnings are OK)
- [ ] Dependency check completes
- [ ] Secret scanning completes

## Note on Rulesets
The repository has a ruleset "Protect main branch" but it doesn't require any status checks. After this PR is merged, consider adding these CI checks as required status checks:
- `Build, Lint and Test`

This would ensure all guardrails must pass before merging to main.