### PR TITLE
fix: use minor version bumps for pre-1.0 breaking changes

### DIFF
--- a/.changeset/breaking-api-improvements.md
+++ b/.changeset/breaking-api-improvements.md
@@ -1,8 +1,8 @@
 ---
-'@codeforbreakfast/eventsourcing-store': major
-'@codeforbreakfast/eventsourcing-projections': major
-'@codeforbreakfast/eventsourcing-aggregates': major
-'@codeforbreakfast/eventsourcing-websocket-transport': major
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-projections': minor
+'@codeforbreakfast/eventsourcing-aggregates': minor
+'@codeforbreakfast/eventsourcing-websocket-transport': minor
 ---
 
 ## Breaking Changes: API Standardization and Service Pattern Improvements


### PR DESCRIPTION
## Summary
- Changed changeset version bumps from `major` to `minor` for all packages
- Ensures next release will be v0.2.0 instead of v1.0.0
- Follows semver convention for pre-1.0 packages where breaking changes use minor bumps

## Context
We're still in pre-1.0 development and making breaking changes. In semver for 0.x versions:
- Patch: backwards compatible bug fixes (0.1.0 -> 0.1.1)
- Minor: breaking changes (0.1.0 -> 0.2.0)
- Major: reserved for going to 1.0.0 (stable release)

## Test plan
- [x] Updated changeset file to use `minor` instead of `major`
- [ ] Run `bun version` to verify it generates 0.2.0 versions
- [ ] Review generated version bumps before merging