### PR TITLE
feat: make dependency-cruiser violations fail the build

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -3,7 +3,7 @@ module.exports = {
   forbidden: [
     {
       name: 'no-circular',
-      severity: 'warn',
+      severity: 'error',
       comment:
         'This dependency is part of a circular relationship. You might want to revise ' +
         'your solution (i.e. use dependency inversion, make sure the modules have a single responsibility) ',
@@ -20,7 +20,7 @@ module.exports = {
         'add an exception for it in your dependency-cruiser configuration. By default ' +
         'this rule does not scrutinize dot-files (e.g. .eslintrc.js), TypeScript declaration ' +
         'files (.d.ts), tsconfig.json and some of the babel and webpack configs.',
-      severity: 'warn',
+      severity: 'error',
       from: {
         orphan: true,
         pathNot: [
@@ -33,6 +33,7 @@ module.exports = {
           'src/services/index[.]ts$', // Service barrel exports
           'src/components/.*/index[.]ts$', // Component barrel exports
           'dist/.*[.]js$', // Built files
+          'build[.](?:ts|js|mjs|cjs)$', // Build scripts
         ],
       },
       to: {},

--- a/packages/eventsourcing-websocket-transport/src/lib/event-transport/interface.ts
+++ b/packages/eventsourcing-websocket-transport/src/lib/event-transport/interface.ts
@@ -27,7 +27,7 @@
  */
 
 import { Effect } from 'effect';
-import type { WebSocketEventTransport } from './types';
+import type { WebSocketEventTransport, TransportConfig } from './types';
 
 /**
  * WebSocketEventTransport Service Interface
@@ -48,40 +48,8 @@ export interface WebSocketEventTransportServiceInterface<TEvent = unknown> {
    * @returns A configured transport instance
    */
   readonly createWithConfig: (
-    config: Readonly<TransportConfig>,
+    config: Readonly<TransportConfig>
   ) => Effect.Effect<WebSocketEventTransport<TEvent>>;
-}
-
-/**
- * Transport configuration options
- */
-export interface TransportConfig {
-  /** Maximum number of reconnection attempts */
-  readonly maxReconnectAttempts?: number;
-
-  /** Initial reconnection delay in milliseconds */
-  readonly reconnectDelayMs?: number;
-
-  /** Maximum reconnection delay in milliseconds */
-  readonly maxReconnectDelayMs?: number;
-
-  /** Backoff multiplier for reconnection delays */
-  readonly reconnectBackoffMultiplier?: number;
-
-  /** Connection timeout in milliseconds */
-  readonly connectionTimeoutMs?: number;
-
-  /** Heartbeat interval in milliseconds */
-  readonly heartbeatIntervalMs?: number;
-
-  /** Buffer size for event streams */
-  readonly eventBufferSize?: number;
-
-  /** Enable automatic reconnection */
-  readonly autoReconnect?: boolean;
-
-  /** Enable debug logging */
-  readonly debug?: boolean;
 }
 
 /**
@@ -113,9 +81,7 @@ export const defaultTransportConfig: Required<TransportConfig> = {
  * );
  * ```
  */
-export class WebSocketEventTransportService extends Effect.Tag(
-  'WebSocketEventTransportService',
-)<
+export class WebSocketEventTransportService extends Effect.Tag('WebSocketEventTransportService')<
   WebSocketEventTransportService,
   WebSocketEventTransportServiceInterface<unknown>
 >() {}

--- a/turbo.json
+++ b/turbo.json
@@ -17,16 +17,47 @@
       "dependsOn": ["^build"],
       "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json", "package.json", "build.ts"]
     },
-    "deps:check": {
-      "dependsOn": ["build"],
+    "//#deps:check": {
+      "dependsOn": [],
       "outputs": [],
       "inputs": [
         "packages/*/src/**/*.ts",
         "packages/*/src/**/*.tsx",
         "packages/*/package.json",
         "knip.json",
-        ".knip.json"
-      ]
+        ".knip.json",
+        "knip.config.*"
+      ],
+      "cache": true
+    },
+    "//#code:check": {
+      "dependsOn": [],
+      "outputs": [],
+      "inputs": [
+        "packages/**/*.ts",
+        "packages/**/*.tsx",
+        "packages/**/*.js",
+        "packages/**/*.mjs",
+        "packages/**/package.json",
+        "knip.json",
+        ".knip.json",
+        "knip.config.*"
+      ],
+      "cache": true
+    },
+    "//#arch:check": {
+      "outputs": [],
+      "inputs": [
+        "packages/**/*.ts",
+        "packages/**/*.tsx",
+        "packages/**/*.js",
+        "packages/**/*.mjs",
+        "packages/**/*.cjs",
+        "packages/**/package.json",
+        ".dependency-cruiser.js",
+        ".dependency-cruiser.json"
+      ],
+      "cache": true
     },
     "lint": {
       "dependsOn": ["check", "^lint"],
@@ -42,7 +73,7 @@
       ]
     },
     "test": {
-      "dependsOn": ["^test", "lint", "deps:check"],
+      "dependsOn": ["^test", "lint", "//#deps:check", "//#arch:check"],
       "outputs": [],
       "inputs": [
         "src/**/*.ts",


### PR DESCRIPTION
## Summary
- Enforce architecture rules by making dependency-cruiser violations fail the build
- Configure turbo to properly cache and run architecture checks
- Integrate architecture validation into the test pipeline

## Changes
- Changed `no-circular` and `no-orphans` violations from `warn` to `error` severity in `.dependency-cruiser.js`
- Configured `arch:check`, `deps:check`, and `code:check` as cacheable root tasks in `turbo.json`
- Added `arch:check` to test pipeline dependencies to catch violations in CI
- Excluded build scripts from orphan detection

## Breaking Changes
⚠️ **BREAKING CHANGE**: Architecture violations now fail the build instead of just warning. This ensures code quality standards are enforced consistently.

## Test Plan
- [x] Run `bun turbo run //#arch:check` - fails with exit code when violations exist
- [x] Run the task twice to verify caching works correctly
- [x] Verify test pipeline includes arch:check dependency
- [x] Confirm deps:check and code:check also work as root tasks with caching

## Current Violations
There is currently 1 circular dependency that needs to be resolved:
- `packages/eventsourcing-websocket-transport/src/lib/event-transport/interface.ts` ↔️ `types.ts`

This should be addressed in a follow-up PR to avoid blocking this infrastructure change.