### PR TITLE
fix(ci): only trigger release workflow for package changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/**'
+      - '.changeset/**'
+      - 'package.json'
+      - 'bun.lockb'
+      - 'pnpm-lock.yaml'
+      - 'turbo.json'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary
- Added path filters to release workflow to prevent unnecessary release attempts
- Workflow now only runs when actual package code or configuration changes

## Problem
The release workflow was running on every push to main, including documentation and CI-only changes. This caused release attempts to fail with "cannot publish over the previously published versions" errors when no actual package changes were made.

## Solution
Added path filters to the workflow trigger to only run when:
- Package source code changes (`packages/**`)
- Changeset files are modified (`.changeset/**`)
- Root package configuration changes (`package.json`, `bun.lockb`, `pnpm-lock.yaml`)
- Turbo configuration changes (`turbo.json`)

This ensures the release process only runs when there are actual changes to release, preventing failed builds for documentation or CI-only changes.

## Test Plan
- [x] Modified workflow syntax is valid
- [x] Path patterns cover all relevant package files
- [ ] Workflow will be skipped for documentation-only changes (will be verified after merge)
- [ ] Workflow will still run for actual package changes

Fixes: https://github.com/CodeForBreakfast/eventsourcing/actions/runs/17892367526