### PR TITLE
fix: update changeset to minor version for package boundary changes

### DIFF
--- a/.changeset/refactor-package-boundaries.md
+++ b/.changeset/refactor-package-boundaries.md
@@ -1,7 +1,7 @@
 ---
-'@codeforbreakfast/eventsourcing-store': patch
-'@codeforbreakfast/eventsourcing-store-postgres': patch
-'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-store-postgres': minor
+'@codeforbreakfast/eventsourcing-aggregates': minor
 ---
 
 Refactored package boundaries for better separation of concerns


### PR DESCRIPTION
The package boundary refactoring includes breaking changes and new features that warrant minor version bumps instead of patches:

- **New package**: `@codeforbreakfast/eventsourcing-store-postgres` (new feature)
- **Breaking changes**: Import paths changed for PostgreSQL users
- **New exports**: `runEventStoreTestSuite` function added to public API

These changes align with semantic versioning for minor releases.