### PR TITLE
refactor: simplify naming conventions and improve API clarity

### DIFF
--- a/.changeset/simplify-naming-conventions.md
+++ b/.changeset/simplify-naming-conventions.md
@@ -1,0 +1,35 @@
+---
+'@codeforbreakfast/eventsourcing-store': minor
+---
+
+Simplify and improve API naming conventions
+
+### Breaking Changes
+
+- Renamed `OptimizedStreamHandler` to `StreamHandler` - there was no non-optimized version, making the "Optimized" prefix misleading
+- Renamed `EnhancedEventStore` interface to `SubscribableEventStore` - explicitly describes what it adds over the base EventStore
+- Renamed factory functions to follow Effect-ts conventions:
+  - `inMemoryEventStore` → `makeInMemoryEventStore`
+  - `enhancedInMemoryEventStore` → `makeSubscribableInMemoryEventStore`
+
+### Migration Guide
+
+Update your imports and usage:
+
+```typescript
+// Before
+import {
+  OptimizedStreamHandler,
+  OptimizedStreamHandlerLive,
+  enhancedInMemoryEventStore,
+} from '@codeforbreakfast/eventsourcing-store';
+
+// After
+import {
+  StreamHandler,
+  StreamHandlerLive,
+  makeSubscribableInMemoryEventStore,
+} from '@codeforbreakfast/eventsourcing-store';
+```
+
+These changes make the API more predictable and easier to understand by removing unnecessary marketing terms and following consistent naming patterns.

--- a/packages/eventsourcing-store/src/index.ts
+++ b/packages/eventsourcing-store/src/index.ts
@@ -6,18 +6,18 @@ export * from './lib/eventstore';
 
 // In-memory implementation
 export {
-  inMemoryEventStore,
-  enhancedInMemoryEventStore,
-  type EnhancedEventStore,
+  makeInMemoryEventStore,
+  makeSubscribableInMemoryEventStore,
+  type SubscribableEventStore,
 } from './lib/inMemory';
 
 // Streaming utilities
 export {
-  OptimizedStreamHandler,
-  OptimizedStreamHandlerLive,
-  makeOptimizedStreamHandler,
+  StreamHandler,
+  StreamHandlerLive,
+  makeStreamHandler,
   StreamingError,
-  type OptimizedStreamHandlerService,
+  type StreamHandlerService,
 } from './lib/streaming';
 
 // Testing utilities

--- a/packages/eventsourcing-store/src/lib/eventstore.unified-read.test.ts
+++ b/packages/eventsourcing-store/src/lib/eventstore.unified-read.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'bun:test';
 import { EventStreamId, EventStreamPosition } from './streamTypes';
 import type { EventStore } from './services';
 import * as InMemoryStore from './inMemory/InMemoryStore';
-import { inMemoryEventStore } from './inMemory/inMemoryEventStore';
+import { makeInMemoryEventStore } from './inMemory/inMemoryEventStore';
 
 // Test event schema
 const TestEvent = Schema.Struct({
@@ -32,7 +32,7 @@ describe('EventStore Unified Read API', () => {
       TestEventStoreService,
       pipe(
         InMemoryStore.make<TestEvent>(),
-        Effect.flatMap(inMemoryEventStore),
+        Effect.flatMap(makeInMemoryEventStore),
         Effect.map((store) => store as unknown as EventStore<TestEvent>)
       )
     );

--- a/packages/eventsourcing-store/src/lib/inMemory/inMemory.spec.ts
+++ b/packages/eventsourcing-store/src/lib/inMemory/inMemory.spec.ts
@@ -1,7 +1,7 @@
 import { Logger, Effect, Layer, Schema, pipe } from 'effect';
 import { runEventStoreTestSuite, FooEventStore } from '../testing/eventstore-test-suite';
 import { encodedEventStore } from '../eventstore';
-import { inMemoryEventStore } from './index';
+import { makeInMemoryEventStore } from './index';
 import * as InMemoryStore from './InMemoryStore';
 
 const LoggerLive = Logger.pretty;
@@ -12,7 +12,7 @@ type FooEvent = typeof FooEvent.Type;
 export const FooEventStoreTest = (store: Readonly<InMemoryStore.InMemoryStore<FooEvent>>) =>
   Layer.effect(
     FooEventStore,
-    pipe(store, inMemoryEventStore, Effect.map(encodedEventStore(FooEvent)))
+    pipe(store, makeInMemoryEventStore, Effect.map(encodedEventStore(FooEvent)))
   );
 
 // Run the shared test suite for the in-memory implementation

--- a/packages/eventsourcing-store/src/lib/inMemory/inMemoryEventStore.ts
+++ b/packages/eventsourcing-store/src/lib/inMemory/inMemoryEventStore.ts
@@ -43,13 +43,13 @@ const applyReadOptions = <T>(
       : (s) => s
   );
 
-export interface EnhancedEventStore<T> extends EventStore<T> {
+export interface SubscribableEventStore<T> extends EventStore<T> {
   readonly subscribeToStream: (
     streamId: EventStreamPosition['streamId']
   ) => Effect.Effect<Stream.Stream<T, never>, EventStoreError, Scope.Scope>;
 }
 
-export const inMemoryEventStore = <T>(
+export const makeInMemoryEventStore = <T>(
   store: Readonly<InMemoryStore.InMemoryStore<T>>
 ): Effect.Effect<EventStore<T>, never, never> =>
   Effect.succeed({
@@ -101,11 +101,11 @@ export const inMemoryEventStore = <T>(
     },
   });
 
-export const enhancedInMemoryEventStore = <T>(
+export const makeSubscribableInMemoryEventStore = <T>(
   store: Readonly<InMemoryStore.InMemoryStore<T>>
-): Effect.Effect<EnhancedEventStore<T>, never, never> =>
+): Effect.Effect<SubscribableEventStore<T>, never, never> =>
   pipe(
-    inMemoryEventStore(store),
+    makeInMemoryEventStore(store),
     Effect.map((baseStore) => ({
       ...baseStore,
       subscribeToStream: (streamId: EventStreamPosition['streamId']) =>

--- a/packages/eventsourcing-store/src/lib/streaming/StreamHandler.test.ts
+++ b/packages/eventsourcing-store/src/lib/streaming/StreamHandler.test.ts
@@ -1,13 +1,13 @@
 import { Effect, pipe } from 'effect';
 import { describe, expect, it } from 'bun:test';
-import { OptimizedStreamHandler, OptimizedStreamHandlerLive } from './OptimizedStreamHandler';
+import { StreamHandler, StreamHandlerLive } from './StreamHandler';
 
-describe('OptimizedStreamHandler', () => {
+describe('StreamHandler', () => {
   // Single minimal test to ensure the module loads
   it('should create a handler implementation', async () => {
     // Create the tag and layer for testing
-    const TestStreamHandler = OptimizedStreamHandler<string, string>();
-    const TestStreamHandlerLive = OptimizedStreamHandlerLive<string, string>();
+    const TestStreamHandler = StreamHandler<string, string>();
+    const TestStreamHandlerLive = StreamHandlerLive<string, string>();
 
     const program = pipe(
       TestStreamHandler,

--- a/packages/eventsourcing-store/src/lib/streaming/StreamHandler.ts
+++ b/packages/eventsourcing-store/src/lib/streaming/StreamHandler.ts
@@ -9,9 +9,9 @@ export class StreamingError extends Data.TaggedError('StreamingError')<{
 }> {}
 
 /**
- * Interface for optimized event streaming
+ * Interface for event streaming
  */
-export interface OptimizedStreamHandlerService<TEvent, TStreamId extends string = string> {
+export interface StreamHandlerService<TEvent, TStreamId extends string = string> {
   /**
    * Subscribe to events for a specific stream
    */
@@ -45,13 +45,13 @@ export interface OptimizedStreamHandlerService<TEvent, TStreamId extends string 
  * Note: Using Context.GenericTag here because Effect.Tag doesn't support generic parameters
  * This is a valid use case for GenericTag with complex generic types
  */
-export const OptimizedStreamHandler = <TEvent = unknown, TStreamId extends string = string>() =>
-  Context.GenericTag<OptimizedStreamHandlerService<TEvent, TStreamId>>('OptimizedStreamHandler');
+export const StreamHandler = <TEvent = unknown, TStreamId extends string = string>() =>
+  Context.GenericTag<StreamHandlerService<TEvent, TStreamId>>('StreamHandler');
 
 /**
- * Create the optimized stream handler with Effect's PubSub
+ * Create the stream handler with Effect's PubSub
  */
-export const makeOptimizedStreamHandler = <TEvent, TStreamId extends string = string>() =>
+export const makeStreamHandler = <TEvent, TStreamId extends string = string>() =>
   pipe(
     // Create references to our handler state
     Effect.all([Ref.make(new Map<string, PubSub.PubSub<TEvent>>()), Ref.make(0)]),
@@ -94,7 +94,7 @@ export const makeOptimizedStreamHandler = <TEvent, TStreamId extends string = st
       };
 
       // Create the handler implementation
-      const handler: OptimizedStreamHandlerService<TEvent, TStreamId> = {
+      const handler: StreamHandlerService<TEvent, TStreamId> = {
         subscribeToStream: (streamId) =>
           Effect.catchAll(
             pipe(
@@ -158,12 +158,9 @@ export const makeOptimizedStreamHandler = <TEvent, TStreamId extends string = st
   );
 
 /**
- * Live Layer implementation of the OptimizedStreamHandler
+ * Live Layer implementation of the StreamHandler
  */
-export const OptimizedStreamHandlerLive = <
-  TEvent = unknown,
-  TStreamId extends string = string,
->() => {
-  const Tag = OptimizedStreamHandler<TEvent, TStreamId>();
-  return Layer.effect(Tag, makeOptimizedStreamHandler<TEvent, TStreamId>());
+export const StreamHandlerLive = <TEvent = unknown, TStreamId extends string = string>() => {
+  const Tag = StreamHandler<TEvent, TStreamId>();
+  return Layer.effect(Tag, makeStreamHandler<TEvent, TStreamId>());
 };

--- a/packages/eventsourcing-store/src/lib/streaming/index.ts
+++ b/packages/eventsourcing-store/src/lib/streaming/index.ts
@@ -1,2 +1,2 @@
-export * from './OptimizedStreamHandler';
+export * from './StreamHandler';
 export * from './connectionManager';


### PR DESCRIPTION
## Summary

- Removed misleading "Optimized" and "Enhanced" prefixes from classes that have no basic versions
- Improved API discoverability by using clear, descriptive names that indicate actual functionality
- Aligned factory function naming with Effect-ts conventions

## Changes

### Renamed Components
- `OptimizedStreamHandler` → `StreamHandler` (there's no non-optimized version)
- `EnhancedEventStore` → `SubscribableEventStore` (explicit about subscription capability)
- `inMemoryEventStore` → `makeInMemoryEventStore` (Effect-ts convention)
- `enhancedInMemoryEventStore` → `makeSubscribableInMemoryEventStore` (clear factory pattern)

### Benefits
- **Cleaner API**: No marketing terms like "Optimized" or "Enhanced" in technical interfaces
- **Better discoverability**: Names clearly indicate what components do
- **Consistent patterns**: Factory functions follow Effect-ts conventions
- **Reduced confusion**: No more wondering where the "non-optimized" version is

## Test plan

- [x] All existing tests pass
- [x] API changes documented in changeset
- [x] Migration guide included in changeset