### PR TITLE
feat(eventsourcing-store): rename write method to append for semantic clarity

### DIFF
--- a/.changeset/rename-write-to-append.md
+++ b/.changeset/rename-write-to-append.md
@@ -1,0 +1,28 @@
+---
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-store-postgres': minor
+'@codeforbreakfast/eventsourcing-aggregates': minor
+---
+
+Rename EventStore `write` method to `append` for better semantic clarity
+
+The `write` method on the EventStore interface has been renamed to `append` to more accurately reflect its purpose - events can only be appended to the end of a stream, not written arbitrarily. The method signature and behavior remain the same, with the position parameter used for optimistic concurrency control to detect conflicts.
+
+### Breaking Changes
+
+- `EventStore.write()` is now `EventStore.append()`
+- All implementations and usages have been updated accordingly
+
+### Migration Guide
+
+Update all calls from:
+
+```typescript
+eventStore.write(position);
+```
+
+To:
+
+```typescript
+eventStore.append(position);
+```

--- a/.changeset/simplified-eventstore-api.md
+++ b/.changeset/simplified-eventstore-api.md
@@ -1,7 +1,7 @@
 ---
-'@codeforbreakfast/eventsourcing-store': major
-'@codeforbreakfast/eventsourcing-store-postgres': major
-'@codeforbreakfast/eventsourcing-projections': major
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-store-postgres': minor
+'@codeforbreakfast/eventsourcing-projections': minor
 '@codeforbreakfast/eventsourcing-aggregates': patch
 ---
 

--- a/.changeset/simplify-eventstore-api.md
+++ b/.changeset/simplify-eventstore-api.md
@@ -1,6 +1,6 @@
 ---
-'@codeforbreakfast/eventsourcing-store': major
-'@codeforbreakfast/eventsourcing-store-postgres': major
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-store-postgres': minor
 ---
 
 Simplified EventStore API to have just two core methods for reading events

--- a/USAGE.md
+++ b/USAGE.md
@@ -292,7 +292,7 @@ const writeEventsWithConcurrency = pipe(
       // Position after event 5 - will fail if stream has advanced beyond this
       positionAfter(EventNumber(5))(streamId),
       Effect.flatMap((position) =>
-        pipe(Stream.fromIterable([event1, event2]), Stream.run(eventStore.write(position)))
+        pipe(Stream.fromIterable([event1, event2]), Stream.run(eventStore.append(position)))
       )
     )
   )

--- a/packages/eventsourcing-aggregates/src/lib/aggregateRootEventStream.ts
+++ b/packages/eventsourcing-aggregates/src/lib/aggregateRootEventStream.ts
@@ -107,7 +107,7 @@ const commit =
             pipe(
               options.events as Chunk.Chunk<TEvent>,
               Stream.fromChunk,
-              Stream.run(eventstore.write(position))
+              Stream.run(eventstore.append(position))
             )
           )
         )

--- a/packages/eventsourcing-store-postgres/README.md
+++ b/packages/eventsourcing-store-postgres/README.md
@@ -91,7 +91,7 @@ const program = pipe(
 
             return pipe(
               Stream.fromIterable(events),
-              Stream.run(eventStore.write(position)),
+              Stream.run(eventStore.append(position)),
               Effect.tap((newPosition) =>
                 Effect.logInfo(`Events written at position: ${JSON.stringify(newPosition)}`)
               ),
@@ -272,7 +272,7 @@ const reliableEventProcessing = pipe(
 Efficiently process multiple events:
 
 ```typescript
-const batchWriteEvents = (events: Array<{ streamId: string; events: UserEvent[] }>) =>
+const batchAppendEvents = (events: Array<{ streamId: string; events: UserEvent[] }>) =>
   pipe(
     EventStore,
     Effect.flatMap((eventStore) =>
@@ -284,7 +284,7 @@ const batchWriteEvents = (events: Array<{ streamId: string; events: UserEvent[] 
               pipe(
                 currentEnd(eventStore)(stream),
                 Effect.flatMap((position) =>
-                  pipe(Stream.fromIterable(streamEvents), Stream.run(eventStore.write(position)))
+                  pipe(Stream.fromIterable(streamEvents), Stream.run(eventStore.append(position)))
                 )
               )
             )
@@ -408,7 +408,7 @@ const eventStoreMetrics = pipe(
   EventStore,
   Effect.map((eventStore) => {
     // Track event write latency
-    const writeLatency = Metrics.histogram('eventstore_write_latency_ms');
+    const appendLatency = Metrics.histogram('eventstore_append_latency_ms');
 
     // Track events written
     const eventsWritten = Metrics.counter('eventstore_events_written_total');
@@ -516,7 +516,7 @@ describe('PostgreSQL Event Store', () => {
 
                           return pipe(
                             Stream.fromIterable(events),
-                            Stream.run(eventStore.write(position)),
+                            Stream.run(eventStore.append(position)),
                             Effect.flatMap(() => eventStore.read(position)),
                             Effect.flatMap(Stream.runCollect),
                             Effect.tap((retrievedEvents) =>

--- a/packages/eventsourcing-store-postgres/src/sqlEventStore.spec.ts
+++ b/packages/eventsourcing-store-postgres/src/sqlEventStore.spec.ts
@@ -114,7 +114,7 @@ describe('PostgreSQL Horizontal Scaling', () => {
         Effect.flatMap((eventstore: EventStore<FooEvent>) =>
           pipe(
             Stream.make({ bar: 'cross-instance-event-1' }, { bar: 'cross-instance-event-2' }),
-            Stream.run(eventstore.write(streamBeginning))
+            Stream.run(eventstore.append(streamBeginning))
           )
         )
       )

--- a/packages/eventsourcing-store-postgres/src/sqlEventStore.ts
+++ b/packages/eventsourcing-store-postgres/src/sqlEventStore.ts
@@ -211,7 +211,7 @@ export const makeSqlEventStoreWithSubscriptionManager = (
     Effect.map(({ eventRows, subscriptionManager, notificationListener }) => {
       // Define an EventStore implementation
       const eventStore: EventStore<string> = {
-        write: (to: EventStreamPosition) => {
+        append: (to: EventStreamPosition) => {
           const sink = Sink.foldEffect(
             to,
             () => true,

--- a/packages/eventsourcing-store/README.md
+++ b/packages/eventsourcing-store/README.md
@@ -51,14 +51,14 @@ type UserEvent = UserRegistered | UserEmailUpdated;
 const eventStoreLayer = inMemoryEventStore<UserEvent>();
 
 // Example: Writing events to a stream
-const writeEvents = (eventStore: EventStore<UserEvent>) => (userId: string, events: UserEvent[]) =>
+const appendEvents = (eventStore: EventStore<UserEvent>) => (userId: string, events: UserEvent[]) =>
   pipe(
     toStreamId(userId),
     Effect.flatMap((streamId) =>
       pipe(
         beginning(streamId),
         Effect.flatMap((position) =>
-          pipe(Stream.fromIterable(events), Stream.run(eventStore.write(position)))
+          pipe(Stream.fromIterable(events), Stream.run(eventStore.append(position)))
         )
       )
     )
@@ -95,7 +95,7 @@ const program = pipe(
       EventStore,
       Effect.flatMap((eventStore) =>
         pipe(
-          writeEvents(eventStore)(userId, events),
+          appendEvents(eventStore)(userId, events),
           Effect.flatMap(() => readUserEvents(eventStore)(userId)),
           Effect.map((collectedEvents) => {
             console.log('Events:', collectedEvents);
@@ -138,7 +138,7 @@ interface EventStore<TEvent> {
 }
 ```
 
-- `write`: Write events to a stream at a specific position
+- `append`: Append events to the end of a stream at a specific position (used for optimistic concurrency control)
 - `read`: Read historical events only (no live updates)
 - `subscribe`: Read historical events then continue with live updates
 

--- a/packages/eventsourcing-store/src/lib/eventstore.ts
+++ b/packages/eventsourcing-store/src/lib/eventstore.ts
@@ -104,12 +104,12 @@ export const encodedEventStore =
   <A, I>(schema: Schema.Schema<A, I>) =>
   (eventstore: Readonly<EventStore<I>>): EventStore<A> =>
     pipe(eventstore, (eventstore) => ({
-      write: (toPosition: EventStreamPosition) => {
+      append: (toPosition: EventStreamPosition) => {
         // Define the expected error type
         type SinkError = ConcurrencyConflictError | ParseResult.ParseError | EventStoreError;
 
         // Get a new sink by creating a type-safe transformation pipeline
-        const originalSink = eventstore.write(toPosition);
+        const originalSink = eventstore.append(toPosition);
 
         // Use mapInputEffect to handle input transformation
         return pipe(

--- a/packages/eventsourcing-store/src/lib/inMemory/inMemoryEventStore.ts
+++ b/packages/eventsourcing-store/src/lib/inMemory/inMemoryEventStore.ts
@@ -14,7 +14,7 @@ export const makeInMemoryEventStore = <T>(
   store: Readonly<InMemoryStore.InMemoryStore<T>>
 ): Effect.Effect<EventStore<T>, never, never> =>
   Effect.succeed({
-    write: (to: EventStreamPosition) =>
+    append: (to: EventStreamPosition) =>
       Sink.foldChunksEffect(
         to,
         () => true,

--- a/packages/eventsourcing-store/src/lib/services.ts
+++ b/packages/eventsourcing-store/src/lib/services.ts
@@ -10,11 +10,12 @@ import {
 // EventStore service interface - Simplified API
 export interface EventStore<TEvent> {
   /**
-   * Write events to a stream at a specific position
-   * @param to The position in the stream to write to
-   * @returns A sink that writes events and returns the new stream position
+   * Append events to the end of a stream at a specific position
+   * @param to The expected position in the stream (used for optimistic concurrency control)
+   * @returns A sink that appends events and returns the new stream position
+   * @throws {ConcurrencyConflictError} If the stream position doesn't match the expected position
    */
-  readonly write: (
+  readonly append: (
     to: EventStreamPosition
   ) => Sink.Sink<
     EventStreamPosition,

--- a/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
+++ b/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
@@ -63,7 +63,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'baz' }, { bar: 'qux' }),
-                Stream.run(eventstore.write(streamBeginning))
+                Stream.run(eventstore.append(streamBeginning))
               )
             )
           )
@@ -107,7 +107,7 @@ export function runEventStoreTestSuite<E>(
               Effect.flatMap((eventstore: EventStore<FooEvent>) =>
                 pipe(
                   Stream.make({ bar: 'foo' }),
-                  Stream.run(eventstore.write(streamBeginning)),
+                  Stream.run(eventstore.append(streamBeginning)),
                   Effect.flip,
                   Effect.map((error) => {
                     expect(error).toBeInstanceOf(StreamEndMovedError);
@@ -125,7 +125,7 @@ export function runEventStoreTestSuite<E>(
             pipe(
               FooEventStore,
               Effect.flatMap((eventstore: EventStore<FooEvent>) =>
-                pipe(Stream.make({ bar: 'foo' }), Stream.run(eventstore.write(result)))
+                pipe(Stream.make({ bar: 'foo' }), Stream.run(eventstore.append(result)))
               )
             )
           );
@@ -197,7 +197,7 @@ export function runEventStoreTestSuite<E>(
                 Effect.flatMap((eventstore: EventStore<FooEvent>) =>
                   pipe(
                     Stream.make({ bar: 'oh-oh' }),
-                    Stream.run(eventstore.write(result)),
+                    Stream.run(eventstore.append(result)),
                     Effect.flip,
                     Effect.map((error) => {
                       expect(error).toBeInstanceOf(StreamEndMovedError);
@@ -220,7 +220,7 @@ export function runEventStoreTestSuite<E>(
                   pipe(
                     Stream.make({ bar: 'baz' }, { bar: 'qux' }),
                     Stream.run(
-                      eventstore.write(
+                      eventstore.append(
                         pipe(
                           secondStreamId,
                           Effect.flatMap(beginning),
@@ -266,7 +266,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'foo' }),
-                Stream.run(eventstore.write(emptyStreamWrongEnd)),
+                Stream.run(eventstore.append(emptyStreamWrongEnd)),
                 Effect.flip,
                 Effect.map((error) => {
                   expect(error).toBeInstanceOf(StreamEndMovedError);
@@ -325,7 +325,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'immediate-test-1' }, { bar: 'immediate-test-2' }),
-                Stream.run(eventstore.write(streamBeginning))
+                Stream.run(eventstore.append(streamBeginning))
               )
             )
           )
@@ -366,7 +366,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'historical-test-1' }, { bar: 'historical-test-2' }),
-                Stream.run(eventstore.write(streamBeginning))
+                Stream.run(eventstore.append(streamBeginning))
               )
             )
           )
@@ -419,7 +419,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'initial-event' }),
-                Stream.run(eventstore.write(streamBeginning))
+                Stream.run(eventstore.append(streamBeginning))
               )
             )
           )
@@ -473,7 +473,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'live-event-1' }, { bar: 'live-event-2' }),
-                Stream.run(eventstore.write(nextPosition))
+                Stream.run(eventstore.append(nextPosition))
               )
             )
           )
@@ -561,7 +561,7 @@ export function runEventStoreTestSuite<E>(
             Effect.flatMap((eventstore: EventStore<FooEvent>) =>
               pipe(
                 Stream.make({ bar: 'multi-subscriber-event' }),
-                Stream.run(eventstore.write(streamBeginning))
+                Stream.run(eventstore.append(streamBeginning))
               )
             )
           )

--- a/packages/eventsourcing-store/src/lib/testing/simplified-api.spec.ts
+++ b/packages/eventsourcing-store/src/lib/testing/simplified-api.spec.ts
@@ -52,7 +52,7 @@ describe('Simplified EventStore API', () => {
                 { bar: 'event2', index: 1 },
                 { bar: 'event3', index: 2 }
               ),
-              Stream.run(store.write(startPos))
+              Stream.run(store.append(startPos))
             )
           )
         )
@@ -83,7 +83,7 @@ describe('Simplified EventStore API', () => {
           Effect.flatMap((store) =>
             pipe(
               Stream.make({ bar: 'event4', index: 3 }, { bar: 'event5', index: 4 }),
-              Stream.run(store.write(endPos))
+              Stream.run(store.append(endPos))
             )
           )
         )
@@ -135,7 +135,7 @@ describe('Simplified EventStore API', () => {
           Effect.flatMap((store) =>
             pipe(
               Stream.make({ bar: 'historical1', index: 0 }, { bar: 'historical2', index: 1 }),
-              Stream.run(store.write(startPos))
+              Stream.run(store.append(startPos))
             )
           )
         )
@@ -164,7 +164,7 @@ describe('Simplified EventStore API', () => {
                         { bar: 'live2', index: 3 },
                         { bar: 'live3', index: 4 }
                       ),
-                      Stream.run(store.write(currentPos))
+                      Stream.run(store.append(currentPos))
                     );
                   })
                 )
@@ -213,7 +213,7 @@ describe('Simplified EventStore API', () => {
                 { bar: 'event1', index: 1 },
                 { bar: 'event2', index: 2 }
               ),
-              Stream.run(store.write(startPos))
+              Stream.run(store.append(startPos))
             )
           )
         )
@@ -237,7 +237,7 @@ describe('Simplified EventStore API', () => {
                     const currentPos: EventStreamPosition = { streamId, eventNumber: 3 };
                     return pipe(
                       Stream.make({ bar: 'new1', index: 3 }, { bar: 'new2', index: 4 }),
-                      Stream.run(store.write(currentPos))
+                      Stream.run(store.append(currentPos))
                     );
                   })
                 )
@@ -288,7 +288,7 @@ describe('Simplified EventStore API', () => {
                 { bar: 'd', index: 3 },
                 { bar: 'e', index: 4 }
               ),
-              Stream.run(store.write(startPos))
+              Stream.run(store.append(startPos))
             )
           )
         )


### PR DESCRIPTION
## Summary
- Renamed `EventStore.write()` to `EventStore.append()` for better semantic clarity
- Updated all implementations and usages across packages
- Updated documentation and changeset versions to minor (pre-1.0)

## Breaking Changes
The `write` method on EventStore has been renamed to `append` to better reflect that events can only be appended to the end of a stream. The position parameter is used for optimistic concurrency control.

## Migration
Update all calls from:
```typescript
eventStore.write(position)
```
To:
```typescript
eventStore.append(position)
```

## Test plan
- [x] All existing tests pass with renamed method
- [x] Documentation updated
- [x] Changesets created