### PR TITLE
chore: remove unused Slack integration from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Send a Slack notification if a publish happens
-        if: steps.changesets.outputs.published == 'true'
-        # You can do something here, like send a notification to Slack or create GitHub releases
-        run: echo "A new version of packages was published!"


### PR DESCRIPTION
## Summary
- Removed unused Slack notification step from release workflow

## Details
The release workflow had a placeholder step for Slack notifications that wasn't connected to any actual Slack workspace. This step just echoed a message and served no purpose, so it's been removed to clean up the workflow.