### PR TITLE
docs: fix outdated API references in documentation

### DIFF
--- a/packages/eventsourcing-store/README.md
+++ b/packages/eventsourcing-store/README.md
@@ -167,14 +167,14 @@ import { inMemoryEventStore } from '@codeforbreakfast/eventsourcing-store';
 const eventStoreLayer = inMemoryEventStore<MyEvent>();
 ```
 
-### Enhanced In-Memory Store
+### Subscribable In-Memory Store
 
 Includes additional features like stream tracking:
 
 ```typescript
-import { enhancedInMemoryEventStore } from '@codeforbreakfast/eventsourcing-store';
+import { makeSubscribableInMemoryEventStore } from '@codeforbreakfast/eventsourcing-store';
 
-const enhancedLayer = enhancedInMemoryEventStore<MyEvent>();
+const subscribableLayer = makeSubscribableInMemoryEventStore<MyEvent>();
 ```
 
 ## Utility Functions


### PR DESCRIPTION
## Summary
- Updated eventsourcing-store README to use correct API name `makeSubscribableInMemoryEventStore` instead of outdated `enhancedInMemoryEventStore`

## Context
Found outdated API references in documentation that don't match the actual exported APIs from the packages.

## Changes
- Fixed import statement in eventsourcing-store README