### PR TITLE
chore: version packages

### DIFF
--- a/packages/eventsourcing-aggregates/CHANGELOG.md
+++ b/packages/eventsourcing-aggregates/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @codeforbreakfast/eventsourcing-aggregates
 
+## 0.5.1
+
+### Patch Changes
+
+- Fix workspace protocol dependencies in published packages
+
+  The published packages incorrectly included workspace:\* protocol in their dependencies, making them impossible to install outside the monorepo. This patch ensures proper version numbers are used in published packages.
+
+- Updated dependencies []:
+  - @codeforbreakfast/eventsourcing-store@0.6.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-aggregates",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Type-safe aggregate root patterns for event sourcing with Effect - Build bulletproof domain models with functional composition and immutable state management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eventsourcing-projections/CHANGELOG.md
+++ b/packages/eventsourcing-projections/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @codeforbreakfast/eventsourcing-projections
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix workspace protocol dependencies in published packages
+
+  The published packages incorrectly included workspace:\* protocol in their dependencies, making them impossible to install outside the monorepo. This patch ensures proper version numbers are used in published packages.
+
+- Updated dependencies []:
+  - @codeforbreakfast/eventsourcing-store@0.6.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-projections",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Functional event projections and read models with Effect - Transform event streams into queryable views with type-safe, composable projection builders",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eventsourcing-store-postgres/CHANGELOG.md
+++ b/packages/eventsourcing-store-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @codeforbreakfast/eventsourcing-store-postgres
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @codeforbreakfast/eventsourcing-store@0.6.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-store-postgres",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Production-ready PostgreSQL event store with Effect integration - Scalable, ACID-compliant event persistence with type-safe database operations and streaming",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eventsourcing-store/CHANGELOG.md
+++ b/packages/eventsourcing-store/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codeforbreakfast/eventsourcing-store
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix workspace protocol dependencies in published packages
+
+  The published packages incorrectly included workspace:\* protocol in their dependencies, making them impossible to install outside the monorepo. This patch ensures proper version numbers are used in published packages.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-store",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Type-safe event sourcing store with Effect integration - Build resilient, functional event-driven systems with composable error handling and streaming",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eventsourcing-websocket-transport/CHANGELOG.md
+++ b/packages/eventsourcing-websocket-transport/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @codeforbreakfast/eventsourcing-websocket-transport
 
+## 0.3.3
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @codeforbreakfast/eventsourcing-store@0.6.1
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/eventsourcing-websocket-transport/package.json
+++ b/packages/eventsourcing-websocket-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-websocket-transport",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Real-time WebSocket transport for event sourcing with Effect - Stream events to browsers and clients with type-safe, resilient real-time communication",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump package versions to trigger new release
- Fix workspace protocol dependencies in published packages

## Context
The previously published packages incorrectly included `workspace:*` in their dependencies, making them impossible to install outside the monorepo. The changeset publish process will automatically replace these with proper version numbers during release.

## Test plan
- [ ] CI passes
- [ ] Release workflow replaces workspace:* with actual versions
- [ ] Published packages can be installed standalone