### PR TITLE
fix: replace workspace protocol with actual versions in dependencies

### DIFF
--- a/packages/eventsourcing-aggregates/CHANGELOG.md
+++ b/packages/eventsourcing-aggregates/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codeforbreakfast/eventsourcing-aggregates
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix workspace protocol in dependencies
+
+  Replace workspace:\* with proper version constraints to fix npm installation issues
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-aggregates",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Type-safe aggregate root patterns for event sourcing with Effect - Build bulletproof domain models with functional composition and immutable state management",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,7 +60,7 @@
     "effect": "^3.17.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "^0.6.1"
   },
   "devDependencies": {
     "@types/node": "24.5.2",

--- a/packages/eventsourcing-projections/CHANGELOG.md
+++ b/packages/eventsourcing-projections/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codeforbreakfast/eventsourcing-projections
 
+## 0.4.2
+
+### Patch Changes
+
+- Fix workspace protocol in dependencies
+
+  Replace workspace:\* with proper version constraints to fix npm installation issues
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-projections",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Functional event projections and read models with Effect - Transform event streams into queryable views with type-safe, composable projection builders",
   "type": "module",
   "main": "./dist/index.js",
@@ -60,7 +60,7 @@
     "effect": "^3.17.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "^0.6.1"
   },
   "devDependencies": {
     "@types/node": "24.5.2",

--- a/packages/eventsourcing-store-postgres/CHANGELOG.md
+++ b/packages/eventsourcing-store-postgres/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codeforbreakfast/eventsourcing-store-postgres
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix workspace protocol in dependencies
+
+  Replace workspace:\* with proper version constraints to fix npm installation issues
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-store-postgres",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Production-ready PostgreSQL event store with Effect integration - Scalable, ACID-compliant event persistence with type-safe database operations and streaming",
   "type": "module",
   "main": "./dist/index.js",
@@ -64,7 +64,7 @@
     "@effect/platform": "^0.90.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*",
+    "@codeforbreakfast/eventsourcing-store": "^0.6.1",
     "@effect/sql": "0.44.2",
     "@effect/sql-pg": "0.45.1",
     "@effect/experimental": "0.54.6"

--- a/packages/eventsourcing-websocket-transport/CHANGELOG.md
+++ b/packages/eventsourcing-websocket-transport/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codeforbreakfast/eventsourcing-websocket-transport
 
+## 0.3.4
+
+### Patch Changes
+
+- Fix workspace protocol in dependencies
+
+  Replace workspace:\* with proper version constraints to fix npm installation issues
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/eventsourcing-websocket-transport/package.json
+++ b/packages/eventsourcing-websocket-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforbreakfast/eventsourcing-websocket-transport",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Real-time WebSocket transport for event sourcing with Effect - Stream events to browsers and clients with type-safe, resilient real-time communication",
   "type": "module",
   "main": "./dist/index.js",
@@ -63,7 +63,7 @@
     "effect": "^3.17.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "^0.6.1"
   },
   "devDependencies": {
     "@types/node": "24.5.2",


### PR DESCRIPTION
## Summary
- Replace all `workspace:*` references with actual version numbers (`^0.6.1`)
- Bump package versions to publish the fix

## Problem
The published npm packages contained `workspace:*` in their dependencies, making them impossible to install outside the monorepo. This happened because changesets doesn't automatically replace workspace protocol during publish when using Bun.

## Solution  
Manually replaced all workspace references with the correct version constraints before publishing.

## Test plan
- [ ] CI passes
- [ ] After merge and publish, verify npm packages have correct dependencies
- [ ] Test installation: `npm install @codeforbreakfast/eventsourcing-aggregates` should work