### PR TITLE
chore: test patch release for workspace dependency fix

### DIFF
--- a/.changeset/patch-test-release.md
+++ b/.changeset/patch-test-release.md
@@ -1,0 +1,10 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-websocket-transport': patch
+---
+
+Test patch release to verify changeset publish handles workspace protocol correctly
+
+This patch verifies that the changeset publish process properly replaces workspace:\* with actual version numbers when publishing to npm.


### PR DESCRIPTION
## Summary
Adding a patch changeset to trigger a release and test if changeset publish properly handles workspace:* dependencies.

## Context
The published npm packages currently have `workspace:*` in their dependencies, making them unusable. This PR adds a changeset to trigger the release process.

## What happens next
1. When this PR merges, the release workflow will create a Version PR
2. The Version PR will bump versions
3. When the Version PR merges, changeset publish should replace workspace:* with actual versions

## Test plan
- [ ] CI passes
- [ ] Version PR gets created after merge
- [ ] After full release, verify npm packages have proper dependencies (not workspace:*)