### PR TITLE
fix: ensure TypeScript definitions are included in published packages

### DIFF
--- a/.changeset/fix-typescript-definitions.md
+++ b/.changeset/fix-typescript-definitions.md
@@ -1,0 +1,13 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-websocket-transport': patch
+---
+
+Fix TypeScript definition generation in build process
+
+The build process was not properly generating TypeScript definition files for published packages due to incremental compilation cache issues. This fix adds the `--force` flag to the TypeScript compiler to ensure definition files are always generated during the build process.
+
+This resolves issues where consumers of these packages would not have proper TypeScript intellisense and type checking.

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build --force",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build --force",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build --force",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build --force",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/eventsourcing-websocket-transport/package.json
+++ b/packages/eventsourcing-websocket-transport/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun --format esm --external effect --external @effect/* --external @codeforbreakfast/* && bun x tsc --build --force",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## Summary

Fixes TypeScript definition generation in the build process for all packages. The published npm packages were missing TypeScript definition files (.d.ts) due to incremental compilation cache issues.

## Changes

- Added `--force` flag to TypeScript compiler in all package build scripts
- This ensures TypeScript definitions are always generated during the build process
- Resolves incremental compilation cache preventing .d.ts file generation

## Impact

- All packages will now include proper TypeScript definition files when published
- Users will have proper TypeScript IntelliSense and type checking when consuming these packages
- Fixes missing type definitions that were causing development issues

## Test Plan

- [x] Verified build process generates .d.ts files
- [x] Confirmed npm pack includes TypeScript definitions
- [x] Created changeset for all affected packages

Closes: TypeScript definitions missing from published packages