### PR TITLE
fix: remove clean step from prepublishOnly to maintain build dependency chain

### DIFF
--- a/.changeset/fix-prepublishonly-build-chain.md
+++ b/.changeset/fix-prepublishonly-build-chain.md
@@ -1,0 +1,13 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-websocket-transport': patch
+---
+
+Fix prepublishOnly script to maintain build dependency chain
+
+The prepublishOnly script was doing a clean build (`clean && build`) which broke the dependency chain established by Turbo's build ordering. This caused packages that depend on other workspace packages to fail TypeScript compilation during publishing because their dependencies' TypeScript definitions weren't available.
+
+Changed prepublishOnly from `bun run clean && bun run build` to just `bun run build` to maintain the build artifacts and dependency chain established by the main build process.

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "publish:package": "bun publish --access public",
-    "prepublishOnly": "bun run clean && bun run build"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "event-sourcing",

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "publish:package": "bun publish --access public",
-    "prepublishOnly": "bun run clean && bun run build"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "event-sourcing",

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "publish:package": "bun publish --access public",
-    "prepublishOnly": "bun run clean && bun run build"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "event-sourcing",

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "publish:package": "bun publish --access public",
-    "prepublishOnly": "bun run clean && bun run build"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "event-sourcing",

--- a/packages/eventsourcing-websocket-transport/package.json
+++ b/packages/eventsourcing-websocket-transport/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "publish:package": "bun publish --access public",
-    "prepublishOnly": "bun run clean && bun run build"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "event-sourcing",


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure by removing the clean step from prepublishOnly scripts to maintain the build dependency chain.

## Problem

The release workflow was failing with TypeScript compilation errors when publishing packages. The `eventsourcing-projections` package couldn't find TypeScript definitions for `@codeforbreakfast/eventsourcing-store` during the prepublishOnly step.

## Root Cause

The prepublishOnly script was doing `bun run clean && bun run build` which:
1. Deleted all build artifacts including TypeScript definitions
2. Tried to rebuild each package individually
3. Broke the dependency chain that Turbo establishes for proper build ordering

## Solution  

Changed prepublishOnly from `bun run clean && bun run build` to just `bun run build` to:
- Maintain build artifacts from the main build process
- Preserve the dependency chain established by Turbo
- Allow incremental builds that respect workspace dependencies

## Testing

- Tested build process with clean && build
- Verified prepublishOnly works correctly after main build
- Confirmed TypeScript definitions are generated properly

This ensures packages can be published successfully while maintaining proper TypeScript definitions.