### PR TITLE
fix: export InMemoryStore class and factory for testing support

### DIFF
--- a/.changeset/export-inmemory-store.md
+++ b/.changeset/export-inmemory-store.md
@@ -1,0 +1,27 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+---
+
+Export InMemoryStore class and make function for testing support
+
+The `InMemoryStore` class and `make` function (exported as `makeInMemoryStore`) are now available from the main package exports. This allows users to create in-memory event stores for testing scenarios without needing to access internal module paths.
+
+## New exports
+
+- `InMemoryStore` - The class for managing in-memory event storage
+- `makeInMemoryStore` - Factory function to create a new InMemoryStore instance
+
+## Example usage
+
+```typescript
+import { Effect } from 'effect';
+import {
+  InMemoryStore,
+  makeInMemoryStore,
+  makeInMemoryEventStore,
+} from '@codeforbreakfast/eventsourcing-store';
+
+// Create an in-memory store for testing
+const store = await Effect.runPromise(makeInMemoryStore<MyEventType>());
+const eventStore = await Effect.runPromise(makeInMemoryEventStore(store));
+```

--- a/packages/eventsourcing-store/src/index.ts
+++ b/packages/eventsourcing-store/src/index.ts
@@ -9,6 +9,8 @@ export {
   makeInMemoryEventStore,
   makeSubscribableInMemoryEventStore,
   type SubscribableEventStore,
+  InMemoryStore,
+  make as makeInMemoryStore,
 } from './lib/inMemory';
 
 // Streaming utilities

--- a/packages/eventsourcing-store/src/lib/inMemory/export.spec.ts
+++ b/packages/eventsourcing-store/src/lib/inMemory/export.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'bun:test';
+import { Effect } from 'effect';
+import * as MainExports from '../../index';
+
+describe('InMemoryStore Exports', () => {
+  it('should export InMemoryStore class', () => {
+    expect(MainExports.InMemoryStore).toBeDefined();
+    expect(typeof MainExports.InMemoryStore).toBe('function');
+  });
+
+  it('should export makeInMemoryStore function', () => {
+    expect(MainExports.makeInMemoryStore).toBeDefined();
+    expect(typeof MainExports.makeInMemoryStore).toBe('function');
+  });
+
+  it('should be able to create an in-memory store for testing', async () => {
+    type TestEvent = { type: 'test'; data: string };
+
+    const store = await Effect.runPromise(MainExports.makeInMemoryStore<TestEvent>());
+    expect(store).toBeDefined();
+    expect(store).toBeInstanceOf(MainExports.InMemoryStore);
+
+    const eventStore = await Effect.runPromise(MainExports.makeInMemoryEventStore(store));
+    expect(eventStore).toBeDefined();
+    expect(typeof eventStore.append).toBe('function');
+    expect(typeof eventStore.read).toBe('function');
+    expect(typeof eventStore.subscribe).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Export InMemoryStore class from main package exports  
- Export make function as makeInMemoryStore for creating instances
- Fixes issue where InMemoryStore was not accessible for testing

## Problem
Users cannot create in-memory event stores for testing because InMemoryStore is not exported from the published npm packages. The makeInMemoryEventStore function requires an InMemoryStore instance but the class was not publicly accessible.

## Solution
Added exports for:
- `InMemoryStore` - The class for managing in-memory event storage
- `makeInMemoryStore` - Factory function to create a new InMemoryStore instance

## Test plan
- [x] Added test to verify exports work correctly
- [x] All existing tests pass
- [x] Package builds successfully