### PR TITLE
chore: add changeset for documentation updates

### DIFF
--- a/.changeset/docs-update.md
+++ b/.changeset/docs-update.md
@@ -1,0 +1,19 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-protocol-default': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport-contracts': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+---
+
+Documentation updates to match current codebase implementation:
+
+- Fixed incorrect package names and import paths
+- Updated API examples and function signatures
+- Corrected WebSocket usage patterns
+- Removed outdated temporary documentation


### PR DESCRIPTION
## Summary
Adding a changeset for the documentation updates that were just merged, to ensure proper versioning and CI workflow success.

## Context
The previous PR (#72) updated documentation but didn't include a changeset, causing the release workflow to fail when trying to publish already-published versions. This PR adds the appropriate changeset to bump all packages with a patch version for the documentation updates.

## Impact
- CI will pass successfully
- All packages will be bumped to 0.2.1 with updated documentation
- Future documentation-only changes should always include changesets