### PR TITLE
refactor: remove all deprecated code patterns

### DIFF
--- a/packages/eventsourcing-store/src/lib/errors.test.ts
+++ b/packages/eventsourcing-store/src/lib/errors.test.ts
@@ -15,9 +15,6 @@ import {
   isEventSourcingError,
 } from './errors';
 
-// StreamEndMovedError is now an alias for ConcurrencyConflictError
-const StreamEndMovedError = ConcurrencyConflictError;
-
 describe('Event Sourcing Errors', () => {
   describe('EventStoreError', () => {
     it('should create error with all fields', () => {
@@ -61,20 +58,6 @@ describe('Event Sourcing Errors', () => {
 
       expect(retryable.retryable).toBe(true);
       expect(fatal.retryable).toBe(false);
-    });
-  });
-
-  describe('StreamEndMovedError', () => {
-    it('should contain version information', () => {
-      const error = new StreamEndMovedError({
-        streamId: 'test-stream',
-        expectedVersion: 5,
-        actualVersion: 10,
-      });
-
-      expect(error.streamId).toBe('test-stream');
-      expect(error.expectedVersion).toBe(5);
-      expect(error.actualVersion).toBe(10);
     });
   });
 

--- a/packages/eventsourcing-store/src/lib/eventstore.ts
+++ b/packages/eventsourcing-store/src/lib/eventstore.ts
@@ -75,8 +75,6 @@ export type { EventStore as EventStoreServiceInterface } from './services'; // A
 export { EventStoreService } from './services';
 // Re-export errors from errors module
 export { ConcurrencyConflictError } from './errors';
-// StreamEndMovedError is deprecated - re-export as alias for backward compatibility
-export { ConcurrencyConflictError as StreamEndMovedError } from './errors';
 
 /**
  * Creates an event store that encodes/decodes events using a schema

--- a/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
+++ b/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
@@ -1,7 +1,7 @@
 import { Chunk, Effect, Layer, ParseResult, Schema, Stream, pipe } from 'effect';
 import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { EventStreamId, EventStreamPosition, beginning } from '../streamTypes';
-import { type EventStore, StreamEndMovedError } from '../eventstore';
+import { type EventStore, ConcurrencyConflictError } from '../eventstore';
 
 // Helper functions for converting stream events
 const toArraySafely = <A>(chunk: Chunk.Chunk<A>): readonly A[] => Chunk.toReadonlyArray(chunk);
@@ -110,7 +110,7 @@ export function runEventStoreTestSuite<E>(
                   Stream.run(eventstore.append(streamBeginning)),
                   Effect.flip,
                   Effect.map((error) => {
-                    expect(error).toBeInstanceOf(StreamEndMovedError);
+                    expect(error).toBeInstanceOf(ConcurrencyConflictError);
                   })
                 )
               )
@@ -200,7 +200,7 @@ export function runEventStoreTestSuite<E>(
                     Stream.run(eventstore.append(result)),
                     Effect.flip,
                     Effect.map((error) => {
-                      expect(error).toBeInstanceOf(StreamEndMovedError);
+                      expect(error).toBeInstanceOf(ConcurrencyConflictError);
                     })
                   )
                 )
@@ -269,7 +269,7 @@ export function runEventStoreTestSuite<E>(
                 Stream.run(eventstore.append(emptyStreamWrongEnd)),
                 Effect.flip,
                 Effect.map((error) => {
-                  expect(error).toBeInstanceOf(StreamEndMovedError);
+                  expect(error).toBeInstanceOf(ConcurrencyConflictError);
                 })
               )
             )

--- a/packages/eventsourcing-websocket/src/index.ts
+++ b/packages/eventsourcing-websocket/src/index.ts
@@ -35,15 +35,10 @@
 // Primary convenience functions
 export {
   connect,
-  createBasicProtocolContext,
-  createWebSocketConnector,
   createWebSocketProtocolStack,
   createWebSocketConnectorLayer,
   DefaultWebSocketConfig,
   WebSocketEventSourcingInfo,
-  // Migration helpers
-  connectWebSocket,
-  createWebSocketProtocol,
   // Types
   type WebSocketConnectOptions,
 } from './lib/index.js';
@@ -142,9 +137,9 @@ const protocol = yield* connect("ws://localhost:8080");
     description: 'Migrating from deprecated websocket packages',
     before: `
 // OLD: Legacy WebSocket event sourcing package
-import { connectWebSocketEventSourcing } from '@old/websocket-eventsourcing';
+import { connectWebSocket } from '@old/websocket-eventsourcing';
 
-const client = yield* connectWebSocketEventSourcing(url, options);
+const client = yield* connectWebSocket(url, options);
     `,
     after: `
 // NEW: Modern Effect-based package
@@ -165,14 +160,12 @@ import { connect } from '@codeforbreakfast/eventsourcing-websocket';
 const protocol = yield* connect("ws://localhost:8080");
   `,
   withCustomContext: `
-import { connect, createBasicProtocolContext } from '@codeforbreakfast/eventsourcing-websocket';
+import { connect } from '@codeforbreakfast/eventsourcing-websocket';
 
-const context = createBasicProtocolContext({
-  sessionId: "my-session-id",
-  userId: "user-123"
-});
+const sessionId = crypto.randomUUID();
+const correlationId = crypto.randomUUID();
 
-const protocol = yield* connect("ws://localhost:8080", { context });
+const protocol = yield* connect("ws://localhost:8080");
   `,
   withConfiguration: `
 import { connect } from '@codeforbreakfast/eventsourcing-websocket';

--- a/packages/eventsourcing-websocket/src/lib/index.ts
+++ b/packages/eventsourcing-websocket/src/lib/index.ts
@@ -51,19 +51,6 @@ export const connect = (
 };
 
 /**
- * @deprecated Use connect() directly
- */
-export const createBasicProtocolContext = () => ({
-  sessionId: crypto.randomUUID(),
-  correlationId: crypto.randomUUID(),
-});
-
-/**
- * @deprecated Use WebSocketConnector directly
- */
-export const createWebSocketConnector = (): typeof WebSocketConnector => WebSocketConnector;
-
-/**
  * Create protocol stack as layer
  */
 export const createWebSocketProtocolStack = (
@@ -80,18 +67,6 @@ export const createWebSocketProtocolStack = (
  * Create protocol connector layer (alias for createWebSocketProtocolStack)
  */
 export const createWebSocketConnectorLayer = (url: string) => createWebSocketProtocolStack(url);
-
-/**
- * @deprecated Use connect() instead
- */
-export const connectWebSocket = (url: string, options?: WebSocketConnectOptions) =>
-  connect(url, options);
-
-/**
- * @deprecated Use connect() instead
- */
-export const createWebSocketProtocol = (url: string, options?: WebSocketConnectOptions) =>
-  connect(url, options);
 
 export const WebSocketEventSourcingInfo = {
   name: '@codeforbreakfast/eventsourcing-websocket',


### PR DESCRIPTION
## Summary
Clean up deprecated code patterns across the eventsourcing packages to modernize the codebase.

## Changes Made

### eventsourcing-websocket package
- Removed deprecated functions:
  - `createBasicProtocolContext()` - deprecated helper function
  - `createWebSocketConnector()` - deprecated connector factory  
  - `connectWebSocket()` - deprecated connection function
  - `createWebSocketProtocol()` - deprecated protocol factory
- Updated tests to use only modern APIs
- Simplified test suite to focus on current functionality

### eventsourcing-store package
- Removed deprecated `StreamEndMovedError` alias
- Updated all references to use `ConcurrencyConflictError` directly
- Cleaned up deprecated test cases
- Updated eventstore test suite imports

### Context.GenericTag Usage
- Kept usage in `StreamHandler` as it's still valid for complex generic types where `Effect.Tag` doesn't work (per CLAUDE.md guidelines)

## Test Status
✅ All tests passing - verified no regressions introduced

## Breaking Changes
⚠️ This removes deprecated APIs that were marked for removal:
- `createBasicProtocolContext`, `createWebSocketConnector`, `connectWebSocket`, `createWebSocketProtocol`
- `StreamEndMovedError` export (use `ConcurrencyConflictError` instead)

Users should migrate to the modern APIs before upgrading.