### PR TITLE
refactor: remove unimplemented WebSocket configuration options

### DIFF
--- a/.changeset/remove-unimplemented-websocket-config.md
+++ b/.changeset/remove-unimplemented-websocket-config.md
@@ -1,0 +1,21 @@
+---
+'@codeforbreakfast/eventsourcing-websocket': major
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+---
+
+Remove unimplemented WebSocket configuration options and update documentation
+
+**Breaking Changes for @codeforbreakfast/eventsourcing-websocket:**
+
+- Removed unused `DefaultWebSocketConfig` export
+- Removed unused `WebSocketConnectOptions` interface
+- Removed unused `WebSocketEventSourcingInfo` export
+- Simplified `connect()` function to only accept URL parameter
+
+**Improvements:**
+
+- Updated README to reflect actual implementation status rather than aspirational roadmap
+- Removed misleading "TDD placeholder" comment from WebSocket server implementation
+- Cleaned up test files to remove references to deleted configuration options
+
+These configuration options were never actually used by the implementation and provided no functionality. The WebSocket packages are fully implemented and ready for use.

--- a/packages/eventsourcing-transport-websocket/src/index.ts
+++ b/packages/eventsourcing-transport-websocket/src/index.ts
@@ -11,7 +11,7 @@
 // Main transport implementation and layer
 export { WebSocketConnector, WebSocketTransportLive } from './lib/websocket-transport';
 
-// Server transport implementation (TDD placeholder)
+// Server transport implementation
 export { WebSocketAcceptor } from './lib/websocket-server';
 
 // Re-export transport contracts for convenience

--- a/packages/eventsourcing-websocket/README.md
+++ b/packages/eventsourcing-websocket/README.md
@@ -1,75 +1,70 @@
 # @codeforbreakfast/eventsourcing-websocket
 
-**WebSocket integration package** - Combines WebSocket transport with event sourcing protocols (coming soon).
+**WebSocket integration package** - Combines WebSocket transport with event sourcing protocols for rapid development.
 
-> ⚠️ **Note**: This package will provide a batteries-included WebSocket event sourcing solution once the protocol layer is implemented. For now, use the transport package directly.
+## Features
 
-## Current Status
+- ✅ **WebSocket Transport** - Full client and server WebSocket implementation
+- ✅ **Protocol Layer** - Command/event protocol with optimistic concurrency
+- ✅ **Convenience API** - One-line setup for event sourcing over WebSocket
 
-This package is under development. It will combine:
+## Installation
 
-- ✅ **WebSocket Transport** (`@codeforbreakfast/eventsourcing-transport-websocket`) - COMPLETED
-- 🚧 **Protocol Layer** (`@codeforbreakfast/eventsourcing-protocol-default`) - IN PROGRESS
-- 🔜 **Convenience API** - PLANNED
+```bash
+bun add @codeforbreakfast/eventsourcing-websocket
+```
 
-## Available Now
+## Quick Start
 
-While the convenience package is being developed, you can use the WebSocket transport directly:
+```typescript
+import { connect } from '@codeforbreakfast/eventsourcing-websocket';
+import { Effect, pipe } from 'effect';
+
+const program = Effect.scoped(
+  Effect.gen(function* () {
+    // Connect with batteries-included protocol
+    const protocol = yield* connect('ws://localhost:8080');
+
+    // Send commands and receive events seamlessly
+    const result = yield* protocol.sendCommand({
+      id: 'cmd-1',
+      target: 'user:123',
+      type: 'user.register',
+      payload: { email: 'user@example.com' },
+    });
+
+    // Subscribe to events
+    const events = yield* protocol.subscribeToEvents('user:123');
+  })
+);
+```
+
+## Advanced Usage
+
+### Custom Configuration
+
+```typescript
+import { connect, makeWebSocketProtocolLayer } from '@codeforbreakfast/eventsourcing-websocket';
+import { Layer, Effect } from 'effect';
+
+// Create a custom layer for dependency injection
+const customLayer = makeWebSocketProtocolLayer('ws://localhost:8080');
+
+const program = Effect.gen(function* () {
+  const protocol = yield* Protocol;
+  // Use protocol...
+}).pipe(Effect.provide(customLayer));
+```
+
+### Server-side Usage
+
+For server implementations, use the transport package directly:
 
 ```bash
 bun add @codeforbreakfast/eventsourcing-transport-websocket
 ```
 
-```typescript
-import { WebSocketConnector } from '@codeforbreakfast/eventsourcing-transport-websocket';
-import { Effect, Stream, pipe } from 'effect';
-
-const program = Effect.scoped(
-  Effect.gen(function* () {
-    // Connect to WebSocket server
-    const transport = yield* WebSocketConnector.connect('ws://localhost:8080');
-
-    // Use the transport for messaging
-    yield* transport.publish({
-      id: makeMessageId('msg-1'),
-      type: 'my.message',
-      payload: { data: 'Hello!' },
-    });
-  })
-);
-```
-
-See the [WebSocket Transport README](../eventsourcing-transport-websocket/README.md) for complete documentation.
-
-## Coming Soon
-
-Once the protocol layer is complete, this package will provide:
-
-- **One-line setup** for event sourcing over WebSocket
-- **Pre-configured stack** with transport and protocol layers
-- **Sensible defaults** for production use
-- **Full customization** when needed
-- **Migration helpers** from separate packages
-
-## Roadmap
-
-1. ✅ **Phase 1**: WebSocket Transport (COMPLETED)
-   - Client connector implementation
-   - Server acceptor implementation
-   - Connection management
-   - Message delivery
-
-2. 🚧 **Phase 2**: Protocol Layer (IN PROGRESS)
-   - Command handling
-   - Event streaming
-   - Aggregate management
-   - Optimistic concurrency
-
-3. 🔜 **Phase 3**: Convenience Package
-   - Simplified API
-   - Default configurations
-   - Migration helpers
-   - Documentation
+See the [WebSocket Transport README](../eventsourcing-transport-websocket/README.md) for server setup.
 
 ## Contributing
 

--- a/packages/eventsourcing-websocket/src/index.ts
+++ b/packages/eventsourcing-websocket/src/index.ts
@@ -4,10 +4,4 @@
  * Batteries-included WebSocket event sourcing package.
  */
 
-export {
-  connect,
-  makeWebSocketProtocolLayer,
-  DefaultWebSocketConfig,
-  WebSocketEventSourcingInfo,
-  type WebSocketConnectOptions,
-} from './lib/index.js';
+export { connect, makeWebSocketProtocolLayer } from './lib/index.js';

--- a/packages/eventsourcing-websocket/src/lib/index.test.ts
+++ b/packages/eventsourcing-websocket/src/lib/index.test.ts
@@ -6,13 +6,7 @@
 
 import { describe, test, expect } from 'vitest';
 import { Effect } from 'effect';
-import {
-  connect,
-  makeWebSocketProtocolLayer,
-  DefaultWebSocketConfig,
-  WebSocketEventSourcingInfo,
-  type WebSocketConnectOptions,
-} from '../index.js';
+import { connect, makeWebSocketProtocolLayer } from '../index.js';
 
 // ============================================================================
 // Type Tests - Ensure all exports are properly typed
@@ -24,15 +18,9 @@ describe('Type Exports', () => {
     expect(typeof connect).toBe('function');
     expect(typeof makeWebSocketProtocolLayer).toBe('function');
 
-    // Test that configuration objects are available
-    expect(DefaultWebSocketConfig).toBeDefined();
-    expect(DefaultWebSocketConfig.reconnectAttempts).toBe(3);
-    expect(DefaultWebSocketConfig.reconnectDelayMs).toBe(1000);
-
-    // Test package info
-    expect(WebSocketEventSourcingInfo.name).toBe('@codeforbreakfast/eventsourcing-websocket');
-    expect(WebSocketEventSourcingInfo.version).toBe('0.1.0');
-    expect(WebSocketEventSourcingInfo.description).toContain('Batteries-included');
+    // Basic smoke test
+    expect(connect).toBeDefined();
+    expect(makeWebSocketProtocolLayer).toBeDefined();
   });
 });
 
@@ -54,27 +42,6 @@ describe('Convenience API', () => {
 // Configuration Tests
 // ============================================================================
 
-describe('Configuration', () => {
-  test('should have sensible default configuration', () => {
-    expect(DefaultWebSocketConfig.reconnectAttempts).toBe(3);
-    expect(DefaultWebSocketConfig.reconnectDelayMs).toBe(1000);
-  });
-
-  test('should support connection options interface', () => {
-    const config = {
-      reconnectAttempts: 5,
-      reconnectDelayMs: 2000,
-    };
-
-    const options: WebSocketConnectOptions = {
-      config,
-    };
-
-    expect(options.config?.reconnectAttempts).toBe(5);
-    expect(options.config?.reconnectDelayMs).toBe(2000);
-  });
-});
-
 // ============================================================================
 // Integration Tests (Mock-based)
 // ============================================================================
@@ -91,34 +58,12 @@ describe('Integration Patterns', () => {
 
         // For testing, we'll just verify the function exists and has the right signature
         expect(typeof connect).toBe('function');
-        expect(connect.length).toBe(2); // url and optional options
+        expect(connect.length).toBe(1); // Just url
 
         return 'Connection pattern validated';
       });
 
     expect(connectionPattern).toBeDefined();
-  });
-
-  test('should demonstrate advanced configuration pattern', () => {
-    const advancedPattern = () =>
-      Effect.gen(function* () {
-        const options: WebSocketConnectOptions = {
-          config: {
-            reconnectAttempts: 5,
-            reconnectDelayMs: 1500,
-          },
-        };
-
-        // Advanced configuration usage
-        // const protocol = yield* connect("ws://localhost:8080", options);
-
-        expect(options.config?.reconnectAttempts).toBe(5);
-        expect(options.config?.reconnectDelayMs).toBe(1500);
-
-        return 'Advanced pattern validated';
-      });
-
-    expect(advancedPattern).toBeDefined();
   });
 
   test('should demonstrate Layer-based dependency injection pattern', () => {
@@ -171,14 +116,6 @@ describe('API Usage Examples', () => {
 // Package Metadata Tests
 // ============================================================================
 
-describe('Package Metadata', () => {
-  test('should provide comprehensive package information', () => {
-    expect(WebSocketEventSourcingInfo.name).toBe('@codeforbreakfast/eventsourcing-websocket');
-    expect(WebSocketEventSourcingInfo.description).toContain('Batteries-included');
-    expect(WebSocketEventSourcingInfo.version).toBe('0.1.0');
-  });
-});
-
 // ============================================================================
 // Performance and Best Practices Tests
 // ============================================================================
@@ -203,26 +140,5 @@ describe('Performance and Best Practices', () => {
       });
 
     expect(connectionReusePattern).toBeDefined();
-  });
-
-  test('should demonstrate configuration best practices', () => {
-    const configBestPractices = () =>
-      Effect.gen(function* () {
-        // Configure reconnection based on your use case
-        const options: WebSocketConnectOptions = {
-          config: {
-            // Always configure reconnection
-            reconnectAttempts: 5,
-            reconnectDelayMs: 2000,
-          },
-        };
-
-        // const protocol = yield* connect("ws://localhost:8080", options);
-
-        expect(options.config?.reconnectAttempts).toBe(5);
-        return 'Configuration best practices shown';
-      });
-
-    expect(configBestPractices).toBeDefined();
   });
 });

--- a/packages/eventsourcing-websocket/src/lib/index.ts
+++ b/packages/eventsourcing-websocket/src/lib/index.ts
@@ -18,21 +18,11 @@ import type {
 } from '@codeforbreakfast/eventsourcing-transport-contracts';
 import type { Scope } from 'effect/Scope';
 
-export const DefaultWebSocketConfig = {
-  reconnectAttempts: 3,
-  reconnectDelayMs: 1000,
-} as const;
-
-export interface WebSocketConnectOptions {
-  readonly config?: Partial<typeof DefaultWebSocketConfig>;
-}
-
 /**
  * Connect to a WebSocket event sourcing server
  */
 export const connect = (
-  url: string,
-  _options?: WebSocketConnectOptions
+  url: string
 ): Effect.Effect<ProtocolService, TransportError | ConnectionError, Protocol | Scope> => {
   // Create the layer stack
   const protocolLayer = pipe(
@@ -62,9 +52,3 @@ export const makeWebSocketProtocolLayer = (
     Layer.unwrapScoped
   );
 };
-
-export const WebSocketEventSourcingInfo = {
-  name: '@codeforbreakfast/eventsourcing-websocket',
-  description: 'Batteries-included WebSocket event sourcing package',
-  version: '0.1.0',
-} as const;


### PR DESCRIPTION
## Summary

- Remove unused configuration exports from `@codeforbreakfast/eventsourcing-websocket` package
- Update documentation to reflect actual implementation status
- Clean up misleading placeholder comments

## Breaking Changes

**For `@codeforbreakfast/eventsourcing-websocket`:**
- Removed unused `DefaultWebSocketConfig` export
- Removed unused `WebSocketConnectOptions` interface  
- Removed unused `WebSocketEventSourcingInfo` export
- Simplified `connect()` function to only accept URL parameter

## Improvements

- Updated README to show that WebSocket packages are fully implemented (not aspirational)
- Removed "TDD placeholder" comment from WebSocket server implementation
- Cleaned up test files to remove references to deleted configuration options

## Impact

These configuration options were never actually used by the implementation and provided no functionality. Users were being misled by documentation suggesting features were "coming soon" when they were already fully implemented.

The WebSocket packages are ready for production use.

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds for all packages
- [x] Removed references to deleted exports from test files