### PR TITLE
fix: clean up package architecture and improve domain type organization

### DIFF
--- a/.changeset/fix-package-architecture-cleanup.md
+++ b/.changeset/fix-package-architecture-cleanup.md
@@ -1,0 +1,25 @@
+---
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-protocol-default': patch
+---
+
+Improve package architecture and domain type organization
+
+**Breaking changes for `@codeforbreakfast/eventsourcing-store`:**
+
+- Added new domain types `Command`, `Event`, and `CommandResult` schemas that were previously only available in the protocol package
+- These core domain types are now available directly from the store package for better separation of concerns
+
+**Improvements for `@codeforbreakfast/eventsourcing-aggregates`:**
+
+- Fixed architectural violation by removing dependency on protocol implementation
+- Aggregate roots now only depend on store abstractions, creating cleaner layer separation
+- Import domain types directly from store package instead of protocol package
+
+**Improvements for `@codeforbreakfast/eventsourcing-protocol-default`:**
+
+- Domain types (`Command`, `Event`, `CommandResult`) are now imported from store package and re-exported for convenience
+- Maintains backward compatibility while improving architectural boundaries
+
+This change establishes cleaner separation between domain concepts (in store) and transport protocols, making the packages more modular and easier to understand.

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -61,8 +61,7 @@
     "effect": "^3.17.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*",
-    "@codeforbreakfast/eventsourcing-protocol-default": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "24.5.2",

--- a/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
@@ -6,7 +6,7 @@ import {
   CommandRoutingError,
   createCommandProcessingService,
 } from '../index';
-import { Command, Event } from '@codeforbreakfast/eventsourcing-protocol-default';
+import { Command, Event } from '@codeforbreakfast/eventsourcing-store';
 
 // ============================================================================
 // Example Usage of Command Processing Service

--- a/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
@@ -7,8 +7,9 @@ import {
   makeInMemoryStore,
   beginning,
   toStreamId,
+  Command,
+  Event,
 } from '@codeforbreakfast/eventsourcing-store';
-import { Command, Event } from '@codeforbreakfast/eventsourcing-protocol-default';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 import { CommandProcessingService } from './commandProcessingService';
 import { CommandHandler, CommandRouter } from './commandHandling';

--- a/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect';
-import { Command, Event } from '@codeforbreakfast/eventsourcing-protocol-default';
+import { Command, Event } from '@codeforbreakfast/eventsourcing-store';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 
 export interface CommandHandler {

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
@@ -1,6 +1,11 @@
 import { Effect, pipe, Stream } from 'effect';
-import { EventStoreService, beginning, toStreamId } from '@codeforbreakfast/eventsourcing-store';
-import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-protocol-default';
+import {
+  EventStoreService,
+  beginning,
+  toStreamId,
+  Command,
+  CommandResult,
+} from '@codeforbreakfast/eventsourcing-store';
 import { CommandProcessingServiceInterface } from './commandProcessingService';
 import { CommandRouter } from './commandHandling';
 

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect';
-import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-protocol-default';
+import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-store';
 import { CommandProcessingError } from './commandProcessingErrors';
 
 export interface CommandProcessingServiceInterface {

--- a/packages/eventsourcing-protocol-default/src/lib/protocol.ts
+++ b/packages/eventsourcing-protocol-default/src/lib/protocol.ts
@@ -21,7 +21,12 @@ import {
   type TransportError,
   type TransportMessage,
 } from '@codeforbreakfast/eventsourcing-transport-contracts';
-import { EventStreamPosition } from '@codeforbreakfast/eventsourcing-store';
+import {
+  EventStreamPosition,
+  Command,
+  Event,
+  CommandResult,
+} from '@codeforbreakfast/eventsourcing-store';
 
 // Minimum protocol needs:
 // 1. Send command -> get result
@@ -45,33 +50,8 @@ export class ProtocolStateError extends Data.TaggedError('ProtocolStateError')<{
   readonly reason: string;
 }> {}
 
-export const Command = Schema.Struct({
-  id: Schema.String,
-  target: Schema.String,
-  name: Schema.String,
-  payload: Schema.Unknown,
-});
-export type Command = typeof Command.Type;
-
-export const Event = Schema.Struct({
-  position: EventStreamPosition,
-  type: Schema.String,
-  data: Schema.Unknown,
-  timestamp: Schema.Date,
-});
-export type Event = typeof Event.Type;
-
-export const CommandResult = Schema.Union(
-  Schema.Struct({
-    _tag: Schema.Literal('Success'),
-    position: EventStreamPosition,
-  }),
-  Schema.Struct({
-    _tag: Schema.Literal('Failure'),
-    error: Schema.String,
-  })
-);
-export type CommandResult = typeof CommandResult.Type;
+// Re-export domain types for convenience
+export { Command, Event, CommandResult };
 
 // ============================================================================
 // Timestamp Schema

--- a/packages/eventsourcing-store/src/index.ts
+++ b/packages/eventsourcing-store/src/index.ts
@@ -1,5 +1,6 @@
 // Core types
 export * from './lib/streamTypes';
+export * from './lib/domainTypes';
 export * from './lib/errors';
 export * from './lib/services';
 export * from './lib/eventstore';

--- a/packages/eventsourcing-store/src/lib/domainTypes.ts
+++ b/packages/eventsourcing-store/src/lib/domainTypes.ts
@@ -1,0 +1,41 @@
+import { Schema } from 'effect';
+import { EventStreamPosition } from './streamTypes';
+
+/**
+ * Domain command schema
+ * Commands represent intent to change the state of an aggregate
+ */
+export const Command = Schema.Struct({
+  id: Schema.String,
+  target: Schema.String,
+  name: Schema.String,
+  payload: Schema.Unknown,
+});
+export type Command = typeof Command.Type;
+
+/**
+ * Domain event schema
+ * Events represent facts that have happened in the domain
+ */
+export const Event = Schema.Struct({
+  position: EventStreamPosition,
+  type: Schema.String,
+  data: Schema.Unknown,
+  timestamp: Schema.Date,
+});
+export type Event = typeof Event.Type;
+
+/**
+ * Result of processing a command
+ */
+export const CommandResult = Schema.Union(
+  Schema.Struct({
+    _tag: Schema.Literal('Success'),
+    position: EventStreamPosition,
+  }),
+  Schema.Struct({
+    _tag: Schema.Literal('Failure'),
+    error: Schema.String,
+  })
+);
+export type CommandResult = typeof CommandResult.Type;


### PR DESCRIPTION
## Summary

This PR cleans up the package architecture and establishes cleaner boundaries between domain concepts and transport protocols.

## Changes Made

- **Removed broken package**: Deleted `eventsourcing-client-aggregates` which contained only build artifacts
- **Fixed architectural violation**: Moved `Command`, `Event`, and `CommandResult` schemas from protocol package to store package where they belong as core domain concepts
- **Cleaned dependencies**: Removed protocol dependency from aggregates package, establishing proper layer separation
- **Maintained compatibility**: Protocol package now imports and re-exports domain types for backward compatibility

## Architecture Improvements

- **Store layer**: Now contains domain types and event store contracts
- **Aggregates layer**: Only depends on store abstractions, not protocol implementations  
- **Protocol layer**: Implements protocols over transports, re-exports domain types for convenience
- **Transport layer**: Pure transport abstractions (WebSocket, HTTP, etc.)

## Testing

- All builds pass ✅
- All tests pass ✅  
- Architecture validation passes ✅
- Dependencies properly organized ✅

This change creates a cleaner, more modular architecture that's easier to understand and maintain.