### PR TITLE
refactor: separate commands into dedicated package

### DIFF
--- a/.changeset/create-commands-package-refactor.md
+++ b/.changeset/create-commands-package-refactor.md
@@ -1,0 +1,35 @@
+---
+'@codeforbreakfast/eventsourcing-commands': major
+'@codeforbreakfast/eventsourcing-store': major
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-protocol-default': patch
+---
+
+Separate CQRS command types into dedicated package for better architecture
+
+**New Package: `@codeforbreakfast/eventsourcing-commands`**
+
+- Introduces a dedicated package for CQRS command types and schemas
+- Contains `Command` and `CommandResult` schemas that were previously in the store package
+- Establishes proper separation between domain concepts (commands) and event storage
+- Includes comprehensive test coverage and documentation
+
+**Breaking changes for `@codeforbreakfast/eventsourcing-store`:**
+
+- Removed `Command` and `CommandResult` types - these are now in the commands package
+- Store package now focuses purely on event streaming and storage concepts
+- Updated description to reflect pure event streaming focus
+
+**Improvements for other packages:**
+
+- `@codeforbreakfast/eventsourcing-aggregates`: Updated to import command types from commands package
+- `@codeforbreakfast/eventsourcing-protocol-default`: Updated to import command types from commands package, maintains backward compatibility through re-exports
+
+This change establishes cleaner architectural boundaries:
+
+- **Store**: Pure event streaming and storage
+- **Commands**: CQRS command types and schemas
+- **Aggregates**: Domain modeling (uses both events and commands)
+- **Protocol**: Transport implementation (uses both events and commands)
+
+The refactor maintains full backward compatibility at the protocol level while improving the underlying architecture.

--- a/.changeset/create-commands-package-refactor.md
+++ b/.changeset/create-commands-package-refactor.md
@@ -1,6 +1,6 @@
 ---
-'@codeforbreakfast/eventsourcing-commands': major
-'@codeforbreakfast/eventsourcing-store': major
+'@codeforbreakfast/eventsourcing-commands': minor
+'@codeforbreakfast/eventsourcing-store': minor
 '@codeforbreakfast/eventsourcing-aggregates': patch
 '@codeforbreakfast/eventsourcing-protocol-default': patch
 ---

--- a/.changeset/create-commands-package-refactor.md
+++ b/.changeset/create-commands-package-refactor.md
@@ -20,10 +20,10 @@ Separate CQRS command types into dedicated package for better architecture
 - Store package now focuses purely on event streaming and storage concepts
 - Updated description to reflect pure event streaming focus
 
-**Improvements for other packages:**
+**Updated packages:**
 
 - `@codeforbreakfast/eventsourcing-aggregates`: Updated to import command types from commands package
-- `@codeforbreakfast/eventsourcing-protocol-default`: Updated to import command types from commands package, maintains backward compatibility through re-exports
+- `@codeforbreakfast/eventsourcing-protocol-default`: Updated to import command types from commands package
 
 This change establishes cleaner architectural boundaries:
 
@@ -31,5 +31,3 @@ This change establishes cleaner architectural boundaries:
 - **Commands**: CQRS command types and schemas
 - **Aggregates**: Domain modeling (uses both events and commands)
 - **Protocol**: Transport implementation (uses both events and commands)
-
-The refactor maintains full backward compatibility at the protocol level while improving the underlying architecture.

--- a/bun.lock
+++ b/bun.lock
@@ -43,11 +43,27 @@
       "name": "@codeforbreakfast/eventsourcing-aggregates",
       "version": "0.5.7",
       "dependencies": {
-        "@codeforbreakfast/eventsourcing-protocol-default": "workspace:*",
+        "@codeforbreakfast/eventsourcing-commands": "workspace:*",
         "@codeforbreakfast/eventsourcing-store": "workspace:*",
       },
       "devDependencies": {
         "@codeforbreakfast/buntest": "workspace:*",
+        "@types/node": "24.5.2",
+        "effect": "3.17.14",
+        "eslint": "9.36.0",
+        "typescript": "5.9.2",
+      },
+      "peerDependencies": {
+        "effect": "^3.17.0",
+      },
+    },
+    "packages/eventsourcing-commands": {
+      "name": "@codeforbreakfast/eventsourcing-commands",
+      "version": "0.1.0",
+      "dependencies": {
+        "@codeforbreakfast/eventsourcing-store": "workspace:*",
+      },
+      "devDependencies": {
         "@types/node": "24.5.2",
         "effect": "3.17.14",
         "eslint": "9.36.0",
@@ -77,6 +93,7 @@
       "name": "@codeforbreakfast/eventsourcing-protocol-default",
       "version": "0.2.2",
       "dependencies": {
+        "@codeforbreakfast/eventsourcing-commands": "workspace:*",
         "@codeforbreakfast/eventsourcing-store": "workspace:*",
         "@codeforbreakfast/eventsourcing-transport-contracts": "workspace:*",
       },
@@ -264,6 +281,8 @@
     "@codeforbreakfast/buntest": ["@codeforbreakfast/buntest@workspace:packages/buntest"],
 
     "@codeforbreakfast/eventsourcing-aggregates": ["@codeforbreakfast/eventsourcing-aggregates@workspace:packages/eventsourcing-aggregates"],
+
+    "@codeforbreakfast/eventsourcing-commands": ["@codeforbreakfast/eventsourcing-commands@workspace:packages/eventsourcing-commands"],
 
     "@codeforbreakfast/eventsourcing-projections": ["@codeforbreakfast/eventsourcing-projections@workspace:packages/eventsourcing-projections"],
 

--- a/packages/eventsourcing-aggregates/README.md
+++ b/packages/eventsourcing-aggregates/README.md
@@ -544,6 +544,7 @@ const productionProgram = pipe(myAggregateOperation, Effect.provide(postgresEven
 
 ## Related Packages
 
+- **[@codeforbreakfast/eventsourcing-commands](../eventsourcing-commands)** - CQRS command types and schemas
 - **[@codeforbreakfast/eventsourcing-store](../eventsourcing-store)** - Core event store interfaces and in-memory implementation
 - **[@codeforbreakfast/eventsourcing-store-postgres](../eventsourcing-store-postgres)** - PostgreSQL event store implementation
 - **[@codeforbreakfast/eventsourcing-projections](../eventsourcing-projections)** - Read-side projection patterns

--- a/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
@@ -6,7 +6,8 @@ import {
   CommandRoutingError,
   createCommandProcessingService,
 } from '../index';
-import { Command, Event } from '@codeforbreakfast/eventsourcing-store';
+import { Event } from '@codeforbreakfast/eventsourcing-store';
+import { Command } from '@codeforbreakfast/eventsourcing-commands';
 
 // ============================================================================
 // Example Usage of Command Processing Service

--- a/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
@@ -7,9 +7,9 @@ import {
   makeInMemoryStore,
   beginning,
   toStreamId,
-  Command,
   Event,
 } from '@codeforbreakfast/eventsourcing-store';
+import { Command } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 import { CommandProcessingService } from './commandProcessingService';
 import { CommandHandler, CommandRouter } from './commandHandling';

--- a/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
@@ -1,5 +1,6 @@
 import { Effect } from 'effect';
-import { Command, Event } from '@codeforbreakfast/eventsourcing-store';
+import { Event } from '@codeforbreakfast/eventsourcing-store';
+import { Command } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 
 export interface CommandHandler {

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
@@ -1,11 +1,6 @@
 import { Effect, pipe, Stream } from 'effect';
-import {
-  EventStoreService,
-  beginning,
-  toStreamId,
-  Command,
-  CommandResult,
-} from '@codeforbreakfast/eventsourcing-store';
+import { EventStoreService, beginning, toStreamId } from '@codeforbreakfast/eventsourcing-store';
+import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingServiceInterface } from './commandProcessingService';
 import { CommandRouter } from './commandHandling';
 

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect';
-import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-store';
+import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError } from './commandProcessingErrors';
 
 export interface CommandProcessingServiceInterface {

--- a/packages/eventsourcing-commands/README.md
+++ b/packages/eventsourcing-commands/README.md
@@ -1,0 +1,73 @@
+# @codeforbreakfast/eventsourcing-commands
+
+CQRS command types and schemas for event sourcing. This package provides core command handling abstractions with type-safe command and result definitions.
+
+## Overview
+
+This package contains the fundamental CQRS (Command Query Responsibility Segregation) types that bridge the gap between user intentions and domain events. Commands represent requests to change system state, while command results indicate the outcome of processing those commands.
+
+## Installation
+
+```bash
+npm install @codeforbreakfast/eventsourcing-commands
+```
+
+## Key Concepts
+
+- **Commands**: Represent user intent to change aggregate state
+- **Command Results**: Indicate success/failure of command processing
+- **Type Safety**: Full TypeScript support with Effect schemas
+
+## API Reference
+
+### Command
+
+Represents a request to change system state:
+
+```typescript
+import { Command } from '@codeforbreakfast/eventsourcing-commands';
+
+const createUserCommand: Command = {
+  id: 'cmd-123',
+  target: 'user-456',
+  name: 'CreateUser',
+  payload: {
+    name: 'John Doe',
+    email: 'john@example.com',
+  },
+};
+```
+
+### CommandResult
+
+Represents the outcome of command processing:
+
+```typescript
+import { CommandResult } from '@codeforbreakfast/eventsourcing-commands';
+
+// Success result
+const success: CommandResult = {
+  _tag: 'Success',
+  position: { streamId: 'user-456', eventNumber: 1 },
+};
+
+// Failure result
+const failure: CommandResult = {
+  _tag: 'Failure',
+  error: 'User already exists',
+};
+```
+
+## Architecture
+
+This package sits between the domain layer (aggregates) and infrastructure layers (protocols, transports):
+
+- **Domain Layer** → Uses commands to represent business intentions
+- **Application Layer** → Processes commands and returns results
+- **Infrastructure Layer** → Transports commands over various protocols
+
+## Related Packages
+
+- `@codeforbreakfast/eventsourcing-store` - Event storage and streaming
+- `@codeforbreakfast/eventsourcing-aggregates` - Domain aggregate patterns
+- `@codeforbreakfast/eventsourcing-protocol-default` - Protocol implementations

--- a/packages/eventsourcing-commands/package.json
+++ b/packages/eventsourcing-commands/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@codeforbreakfast/eventsourcing-aggregates",
-  "version": "0.5.7",
-  "description": "Type-safe aggregate root patterns for event sourcing with Effect - Build bulletproof domain models with functional composition and immutable state management",
+  "name": "@codeforbreakfast/eventsourcing-commands",
+  "version": "0.1.0",
+  "description": "CQRS command types and schemas for event sourcing - Core command handling abstractions with type-safe command and result definitions",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -28,10 +28,10 @@
     "publish:package": "npm publish --access public"
   },
   "keywords": [
-    "event-sourcing",
-    "aggregates",
-    "aggregate-root",
     "cqrs",
+    "commands",
+    "command-query-separation",
+    "event-sourcing",
     "domain-driven-design",
     "ddd",
     "effect",
@@ -40,18 +40,15 @@
     "fp",
     "typescript",
     "type-safe",
-    "immutable",
-    "domain-modeling",
-    "event-driven",
-    "composable",
-    "state-management"
+    "schemas",
+    "domain-modeling"
   ],
   "author": "Code for Breakfast",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/codeforbreakfast/eventsourcing.git",
-    "directory": "packages/eventsourcing-aggregates"
+    "directory": "packages/eventsourcing-commands"
   },
   "bugs": {
     "url": "https://github.com/codeforbreakfast/eventsourcing/issues"
@@ -61,12 +58,11 @@
     "effect": "^3.17.0"
   },
   "dependencies": {
-    "@codeforbreakfast/eventsourcing-store": "workspace:*",
-    "@codeforbreakfast/eventsourcing-commands": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "24.5.2",
     "@codeforbreakfast/buntest": "workspace:*",
+    "@types/node": "24.5.2",
     "effect": "3.17.14",
     "typescript": "5.9.2",
     "eslint": "9.36.0"

--- a/packages/eventsourcing-commands/package.json
+++ b/packages/eventsourcing-commands/package.json
@@ -61,7 +61,6 @@
     "@codeforbreakfast/eventsourcing-store": "workspace:*"
   },
   "devDependencies": {
-    "@codeforbreakfast/buntest": "workspace:*",
     "@types/node": "24.5.2",
     "effect": "3.17.14",
     "typescript": "5.9.2",

--- a/packages/eventsourcing-commands/src/index.ts
+++ b/packages/eventsourcing-commands/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @codeforbreakfast/eventsourcing-commands
+ *
+ * CQRS command types and schemas for event sourcing.
+ * Core command handling abstractions with type-safe command and result definitions.
+ */
+
+export * from './lib/commands';

--- a/packages/eventsourcing-commands/src/lib/commands.test.ts
+++ b/packages/eventsourcing-commands/src/lib/commands.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { Schema } from 'effect';
+import { Command, CommandResult } from './commands';
+
+describe('Commands Package', () => {
+  describe('Command Schema', () => {
+    test('should validate a valid command', () => {
+      const validCommand = {
+        id: 'cmd-123',
+        target: 'user-456',
+        name: 'CreateUser',
+        payload: { email: 'test@example.com' },
+      };
+
+      const result = Schema.decodeUnknownEither(Command)(validCommand);
+      expect(result._tag).toBe('Right');
+    });
+
+    test('should reject invalid command', () => {
+      const invalidCommand = {
+        id: 'cmd-123',
+        // missing target
+        name: 'CreateUser',
+        payload: { email: 'test@example.com' },
+      };
+
+      const result = Schema.decodeUnknownEither(Command)(invalidCommand);
+      expect(result._tag).toBe('Left');
+    });
+  });
+
+  describe('CommandResult Schema', () => {
+    test('should validate success result', () => {
+      const successResult = {
+        _tag: 'Success',
+        position: {
+          streamId: 'user-456',
+          eventNumber: 1,
+        },
+      };
+
+      const result = Schema.decodeUnknownEither(CommandResult)(successResult);
+      expect(result._tag).toBe('Right');
+    });
+
+    test('should validate failure result', () => {
+      const failureResult = {
+        _tag: 'Failure',
+        error: 'User already exists',
+      };
+
+      const result = Schema.decodeUnknownEither(CommandResult)(failureResult);
+      expect(result._tag).toBe('Right');
+    });
+  });
+});

--- a/packages/eventsourcing-commands/src/lib/commands.ts
+++ b/packages/eventsourcing-commands/src/lib/commands.ts
@@ -1,0 +1,29 @@
+import { Schema } from 'effect';
+import { EventStreamPosition } from '@codeforbreakfast/eventsourcing-store';
+
+/**
+ * Domain command schema
+ * Commands represent intent to change the state of an aggregate
+ */
+export const Command = Schema.Struct({
+  id: Schema.String,
+  target: Schema.String,
+  name: Schema.String,
+  payload: Schema.Unknown,
+});
+export type Command = typeof Command.Type;
+
+/**
+ * Result of processing a command
+ */
+export const CommandResult = Schema.Union(
+  Schema.Struct({
+    _tag: Schema.Literal('Success'),
+    position: EventStreamPosition,
+  }),
+  Schema.Struct({
+    _tag: Schema.Literal('Failure'),
+    error: Schema.String,
+  })
+);
+export type CommandResult = typeof CommandResult.Type;

--- a/packages/eventsourcing-commands/src/lib/integration.test.ts
+++ b/packages/eventsourcing-commands/src/lib/integration.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'bun:test';
+import { Schema } from 'effect';
+import { Command, CommandResult } from './commands';
+import { EventStreamPosition } from '@codeforbreakfast/eventsourcing-store';
+
+describe('Commands Integration', () => {
+  test('should work with store types', () => {
+    // Test that CommandResult integrates properly with EventStreamPosition from store
+    const position: EventStreamPosition = {
+      streamId: 'user-123' as any, // Branded type from store
+      eventNumber: 1,
+    };
+
+    const successResult = {
+      _tag: 'Success' as const,
+      position,
+    };
+
+    const result = Schema.decodeUnknownEither(CommandResult)(successResult);
+    expect(result._tag).toBe('Right');
+  });
+
+  test('should validate command with proper typing', () => {
+    const command = {
+      id: 'cmd-123',
+      target: 'user-456',
+      name: 'CreateUser',
+      payload: {
+        email: 'test@example.com',
+        name: 'John Doe',
+      },
+    };
+
+    const result = Schema.decodeUnknownSync(Command)(command);
+    expect(result.id).toBe('cmd-123');
+    expect(result.target).toBe('user-456');
+    expect(result.name).toBe('CreateUser');
+    expect(result.payload).toEqual({
+      email: 'test@example.com',
+      name: 'John Doe',
+    });
+  });
+});

--- a/packages/eventsourcing-commands/tsconfig.json
+++ b/packages/eventsourcing-commands/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/eventsourcing-protocol-default/package.json
+++ b/packages/eventsourcing-protocol-default/package.json
@@ -67,7 +67,8 @@
   },
   "dependencies": {
     "@codeforbreakfast/eventsourcing-transport-contracts": "workspace:*",
-    "@codeforbreakfast/eventsourcing-store": "workspace:*"
+    "@codeforbreakfast/eventsourcing-store": "workspace:*",
+    "@codeforbreakfast/eventsourcing-commands": "workspace:*"
   },
   "devDependencies": {
     "@codeforbreakfast/eventsourcing-transport-inmemory": "workspace:*",

--- a/packages/eventsourcing-protocol-default/src/lib/protocol.ts
+++ b/packages/eventsourcing-protocol-default/src/lib/protocol.ts
@@ -21,12 +21,8 @@ import {
   type TransportError,
   type TransportMessage,
 } from '@codeforbreakfast/eventsourcing-transport-contracts';
-import {
-  EventStreamPosition,
-  Command,
-  Event,
-  CommandResult,
-} from '@codeforbreakfast/eventsourcing-store';
+import { EventStreamPosition, Event } from '@codeforbreakfast/eventsourcing-store';
+import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 
 // Minimum protocol needs:
 // 1. Send command -> get result

--- a/packages/eventsourcing-protocol-default/src/lib/protocol.ts
+++ b/packages/eventsourcing-protocol-default/src/lib/protocol.ts
@@ -46,8 +46,8 @@ export class ProtocolStateError extends Data.TaggedError('ProtocolStateError')<{
   readonly reason: string;
 }> {}
 
-// Re-export domain types for convenience
-export { Command, Event, CommandResult };
+// Re-export Event for convenience
+export { Event };
 
 // ============================================================================
 // Timestamp Schema

--- a/packages/eventsourcing-protocol-default/src/lib/server-protocol.ts
+++ b/packages/eventsourcing-protocol-default/src/lib/server-protocol.ts
@@ -19,9 +19,8 @@ import {
   type Server,
 } from '@codeforbreakfast/eventsourcing-transport-contracts';
 import { EventStreamId } from '@codeforbreakfast/eventsourcing-store';
+import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import {
-  Command,
-  CommandResult,
   Event,
   CommandMessage,
   CommandResultMessage,

--- a/packages/eventsourcing-store/README.md
+++ b/packages/eventsourcing-store/README.md
@@ -1,6 +1,6 @@
 # @codeforbreakfast/eventsourcing-store
 
-Core types and event store implementations for event sourcing with Effect integration. This package provides the foundational interfaces and in-memory implementations needed to build event-sourced applications using functional programming patterns.
+Pure event streaming and storage for event sourcing with Effect integration. This package provides the foundational event storage interfaces and implementations needed to build event-sourced applications using functional programming patterns.
 
 ## Installation
 

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codeforbreakfast/eventsourcing-store",
   "version": "0.6.7",
-  "description": "Type-safe event sourcing store with Effect integration - Build resilient, functional event-driven systems with composable error handling and streaming",
+  "description": "Pure event streaming and storage with Effect integration - Core event store interfaces and implementations for building resilient, functional event-driven systems",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/eventsourcing-store/src/lib/domainTypes.ts
+++ b/packages/eventsourcing-store/src/lib/domainTypes.ts
@@ -2,18 +2,6 @@ import { Schema } from 'effect';
 import { EventStreamPosition } from './streamTypes';
 
 /**
- * Domain command schema
- * Commands represent intent to change the state of an aggregate
- */
-export const Command = Schema.Struct({
-  id: Schema.String,
-  target: Schema.String,
-  name: Schema.String,
-  payload: Schema.Unknown,
-});
-export type Command = typeof Command.Type;
-
-/**
  * Domain event schema
  * Events represent facts that have happened in the domain
  */
@@ -24,18 +12,3 @@ export const Event = Schema.Struct({
   timestamp: Schema.Date,
 });
 export type Event = typeof Event.Type;
-
-/**
- * Result of processing a command
- */
-export const CommandResult = Schema.Union(
-  Schema.Struct({
-    _tag: Schema.Literal('Success'),
-    position: EventStreamPosition,
-  }),
-  Schema.Struct({
-    _tag: Schema.Literal('Failure'),
-    error: Schema.String,
-  })
-);
-export type CommandResult = typeof CommandResult.Type;


### PR DESCRIPTION
## Summary

• Creates dedicated `@codeforbreakfast/eventsourcing-commands` package 
• Separates command types from event store for cleaner architectural boundaries
• Clean architectural separation between event storage and command handling

## Breaking Changes

Direct imports of Command and CommandResult from `@codeforbreakfast/eventsourcing-store` will no longer work. Update imports to use the new `@codeforbreakfast/eventsourcing-commands` package.

## Test Plan

✅ All existing tests pass  
✅ TypeScript compilation succeeds  
✅ Architecture checks pass  
✅ New package includes comprehensive test coverage