### PR TITLE
refactor!: export InMemoryStore as namespace module

### DIFF
--- a/.changeset/inmemorystore-namespace-export.md
+++ b/.changeset/inmemorystore-namespace-export.md
@@ -1,0 +1,24 @@
+---
+'@codeforbreakfast/eventsourcing-store-inmemory': minor
+'@codeforbreakfast/eventsourcing-aggregates': patch
+---
+
+Export InMemoryStore as namespace following Effect patterns
+
+**BREAKING CHANGE**: InMemoryStore is now exported as a namespace module instead of individual exports.
+
+Before:
+
+```typescript
+import { make } from '@codeforbreakfast/eventsourcing-store-inmemory';
+const store = await make();
+```
+
+After:
+
+```typescript
+import { InMemoryStore } from '@codeforbreakfast/eventsourcing-store-inmemory';
+const store = await InMemoryStore.make();
+```
+
+This change aligns with Effect library conventions where modules like Queue, Ref, etc. are exported as namespaces containing their functions.

--- a/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
@@ -7,7 +7,10 @@ import {
   toStreamId,
   Event,
 } from '@codeforbreakfast/eventsourcing-store';
-import { makeInMemoryEventStore, make } from '@codeforbreakfast/eventsourcing-store-inmemory';
+import {
+  makeInMemoryEventStore,
+  InMemoryStore,
+} from '@codeforbreakfast/eventsourcing-store-inmemory';
 import { Command } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 import { CommandProcessingService } from './commandProcessingService';
@@ -75,7 +78,7 @@ const failingHandler: CommandHandler = {
 
 const testLayer = Layer.effect(
   EventStoreService,
-  pipe(make<unknown>(), Effect.flatMap(makeInMemoryEventStore))
+  pipe(InMemoryStore.make<unknown>(), Effect.flatMap(makeInMemoryEventStore))
 );
 
 // ============================================================================

--- a/packages/eventsourcing-store-inmemory/src/lib/index.ts
+++ b/packages/eventsourcing-store-inmemory/src/lib/index.ts
@@ -1,3 +1,3 @@
 export * from './inMemoryEventStore';
 export * from './subscriptionManager';
-export { type InMemoryStore, make } from './InMemoryStore';
+export * as InMemoryStore from './InMemoryStore';


### PR DESCRIPTION
## Summary
Export InMemoryStore as a namespace module following Effect library conventions

## Breaking Change
InMemoryStore is now exported as a namespace module instead of individual exports.

### Before:
```typescript
import { make } from '@codeforbreakfast/eventsourcing-store-inmemory';
const store = await make();
```

### After:
```typescript
import { InMemoryStore } from '@codeforbreakfast/eventsourcing-store-inmemory';
const store = await InMemoryStore.make();
```

## Motivation
This change aligns with Effect library conventions where modules like Queue, Ref, PubSub, etc. are exported as namespaces containing their functions. This provides better organization and clearer API boundaries.

## Test plan
- [x] All existing tests updated and passing
- [x] Build succeeds for all packages
- [x] Type checking passes