### PR TITLE
fix: ensure pre-1.0 packages use minor version bumps

### DIFF
--- a/.changeset/ensure-minor-versions.md
+++ b/.changeset/ensure-minor-versions.md
@@ -1,0 +1,9 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+---
+
+Ensure pre-1.0 packages use minor version bumps instead of major
+
+Updated changeset configurations to use minor version bumps as the maximum for all pre-1.0 packages, following semantic versioning best practices for pre-release versions. This ensures breaking changes are communicated through minor version increments rather than major version bumps while packages are still in initial development.

--- a/.changeset/in-memory-extraction.md
+++ b/.changeset/in-memory-extraction.md
@@ -1,6 +1,6 @@
 ---
-'@codeforbreakfast/eventsourcing-store': major
-'@codeforbreakfast/eventsourcing-store-inmemory': major
+'@codeforbreakfast/eventsourcing-store': minor
+'@codeforbreakfast/eventsourcing-store-inmemory': minor
 ---
 
 Extract in-memory EventStore implementation into separate package

--- a/.changeset/remove-unimplemented-websocket-config.md
+++ b/.changeset/remove-unimplemented-websocket-config.md
@@ -1,5 +1,5 @@
 ---
-'@codeforbreakfast/eventsourcing-websocket': major
+'@codeforbreakfast/eventsourcing-websocket': minor
 '@codeforbreakfast/eventsourcing-transport-websocket': patch
 ---
 


### PR DESCRIPTION
## Summary
- Updated existing changesets to use minor version bumps instead of major
- Added documentation for pre-1.0 version bump policy
- Ensures breaking changes are properly communicated through minor versions while packages are pre-1.0

## Context
Since all packages are pre-1.0, we should follow semver best practices and use minor version bumps as the maximum bump level. Major version bumps should be reserved for the 1.0 release.

## Changes
- Modified `.changeset/in-memory-extraction.md` to use minor bumps
- Modified `.changeset/remove-unimplemented-websocket-config.md` to use minor bump
- Added new changeset documenting this version policy

## Test Plan
- [x] Changesets have been updated
- [ ] CI will validate the changes
- [ ] Version bumps will be applied correctly when changesets are consumed