### PR TITLE
feat(ci): add reusable setup action with mise and optimized caching

### DIFF
--- a/.changeset/mise-ci-setup-action.md
+++ b/.changeset/mise-ci-setup-action.md
@@ -1,0 +1,17 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+'@codeforbreakfast/buntest': patch
+---
+
+Improved CI/CD infrastructure with standardized mise-based tool management and optimized caching strategies for faster builds and more reliable deployments.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,48 @@
+name: Setup
+description: Set up the environment for the project
+
+inputs:
+  restore-turbo-cache-key:
+    description: 'Additional cache key part to find the turbo cache from an earlier job'
+    default: 'default'
+  turbo-cache-key:
+    description: 'Additional cache key part to use for sharing the updated turbo cache with subsequent jobs'
+    default: 'default'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache bun
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      with:
+        path: |
+          ~/.bun
+        key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('**/package.json') }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-bun-
+
+    - name: Install tools
+      uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+
+    - name: Cache node modules
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      id: node-cache
+      with:
+        path: |
+          node_modules
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('**/package.json', 'bun.lock') }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-node-
+
+    - name: Cache turbo
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      with:
+        path: |
+          .turbo/cache
+        key: ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.turbo-cache-key }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.restore-turbo-cache-key }}-${{ github.sha }}
+          ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.turbo-cache-key }}-
+          ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.restore-turbo-cache-key }}-
+          ${{ runner.os }}-${{ runner.arch }}-turbo-
+
+    - run: bun install
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,33 +32,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          bun-version: latest
-
-      - name: Cache node modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: node-cache
-        with:
-          path: |
-            node_modules
-            ~/.bun
-          key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('**/package.json', 'bun.lockb') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-node-
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Cache turbo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            .turbo/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-turbo-${{ hashFiles('**/package.json', 'bun.lockb', 'turbo.json') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-turbo-${{ hashFiles('**/package.json', 'bun.lockb', 'turbo.json') }}-
-            ${{ runner.os }}-${{ runner.arch }}-turbo-
+          turbo-cache-key: 'ci'
 
       - name: Validate release readiness
         run: bun run release:validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,32 +22,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          bun-version: latest
-
-      - name: Cache node modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: node-cache
-        with:
-          path: |
-            node_modules
-            ~/.bun
-          key: ${{ runner.os }}-${{ runner.arch }}-node-${{ hashFiles('**/package.json', 'bun.lockb') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-node-
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Cache turbo
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            .turbo/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-turbo-
+          turbo-cache-key: 'release'
 
       # Generate a GitHub App token for verified commits
       - name: Generate GitHub App Token


### PR DESCRIPTION
## Summary

- Create standardized `.github/actions/setup` action for environment configuration
- Replace hardcoded bun setup with mise-based tool management
- Implement configurable turbo cache keys for better cache isolation between workflows
- Update CI and release workflows to use the new setup action
- Reduce workflow code duplication and improve maintainability

## Changes Made

- **New setup action**: Centralizes environment setup with mise, bun cache, node_modules cache, and smart turbo cache strategy
- **Workflow updates**: Both `ci.yml` and `release.yml` now use the setup action with appropriate cache keys
- **Cache optimization**: Different turbo cache keys per workflow type prevent cache pollution
- **Tool management**: mise handles all tool versions from `.mise.toml` instead of hardcoded versions

## Test plan

- [x] All existing tests pass (`bun run all`)
- [x] Setup action includes proper caching configuration
- [x] Workflows updated to use setup action with correct parameters
- [x] Changeset created documenting infrastructure improvements