### PR TITLE
feat(workflow): enhance start command with automatic workspace directory addition

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git worktree *), Bash(git fetch:*), Bash(git status:*), Bash(git branch:*), Bash(cd:*), Bash(bun install:*), Bash(pwd:*), Bash(mise trust), Bash(mise install), Bash(git pull:*), Bash(git checkout:*), Bash(git worktree add:*)
+allowed-tools: Bash(git worktree *), Bash(git fetch:*), Bash(git status:*), Bash(git branch:*), Bash(cd:*), Bash(bun install:*), Bash(pwd:*), Bash(mise trust), Bash(mise install), Bash(git pull:*), Bash(git checkout:*), Bash(git worktree add:*), SlashCommand(/add-dir *)
 description: Start a new piece of work using git worktree
 ---
 
@@ -27,6 +27,7 @@ IMPORTANT: Always use worktrees for feature development to maintain clean separa
    - Run `bun install` to set up dependencies in the new worktree
    - Run `git status` to confirm branch and clean state
    - Run `pwd` to show current worktree location
+   - Run `/add-dir` command with the worktree path to enable Claude Code access without permission prompts
 
 **Worktree Benefits:**
 


### PR DESCRIPTION
## Summary
- Enhanced the `/start` command to automatically add the new worktree directory to Claude Code workspace
- Added `SlashCommand(/add-dir *)` to allowed-tools permissions
- Added `/add-dir` step to the worktree setup instructions

## Benefits
- Eliminates manual step of adding worktree directory to workspace
- Prevents permission prompts when Claude Code accesses files in new worktrees
- Improves developer experience with seamless worktree workflow

## Test plan
- [x] Modified `.claude/commands/start.md` to include add-dir functionality
- [x] All existing tests pass (`bun run all`)
- [x] Changes are isolated to workflow tooling (no package impact)
- [x] Conventional commit format followed