### PR TITLE
feat(ci): add OIDC support for npm trusted publishing

### DIFF
--- a/.changeset/trusted-publishing-support.md
+++ b/.changeset/trusted-publishing-support.md
@@ -1,0 +1,7 @@
+---
+'@codeforbreakfast/eventsourcing-monorepo': patch
+---
+
+Add OIDC support for npm trusted publishing in CI/CD workflow
+
+Enables secure package publishing via OpenID Connect (OIDC) authentication, eliminating the need for long-lived NPM tokens. Once configured on npmjs.com, packages will be published using short-lived, cryptographically-secured credentials with automatic provenance attestations.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Required for npm OIDC trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -48,4 +49,3 @@ jobs:
           commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds OIDC authentication support to the release workflow for npm trusted publishing
- Removes dependency on long-lived NPM_TOKEN secrets
- Enables automatic provenance attestation generation

## Changes
- Added `id-token: write` permission to release workflow for OIDC authentication
- Removed NPM_TOKEN environment variable from release workflow

## Next Steps
After merging, manually configure trusted publishing for each npm package on npmjs.com with:
- Repository: `CodeForBreakfast/eventsourcing`
- Workflow: `release.yml`
- Environment: `production` (optional but recommended)

## Benefits
- 🔒 Enhanced security with short-lived credentials
- 📋 Automatic provenance attestations for published packages
- 🔧 Simplified maintenance (no token rotation needed)