### PR TITLE
fix: remove invalid changeset targeting monorepo package

### DIFF
--- a/.changeset/trusted-publishing-support.md
+++ b/.changeset/trusted-publishing-support.md
@@ -1,7 +1,0 @@
----
-'@codeforbreakfast/eventsourcing-monorepo': patch
----
-
-Add OIDC support for npm trusted publishing in CI/CD workflow
-
-Enables secure package publishing via OpenID Connect (OIDC) authentication, eliminating the need for long-lived NPM tokens. Once configured on npmjs.com, packages will be published using short-lived, cryptographically-secured credentials with automatic provenance attestations.


### PR DESCRIPTION
Removes the invalid changeset file that was targeting the private monorepo package, which was blocking the release workflow.