### PR TITLE
fix: correct changeset to target published packages instead of monorepo root

### DIFF
--- a/.changeset/npm-oidc-support.md
+++ b/.changeset/npm-oidc-support.md
@@ -1,5 +1,16 @@
 ---
-'@codeforbreakfast/eventsourcing-monorepo': patch
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
 ---
 
 Add npm as dev dependency to support OIDC trusted publishing


### PR DESCRIPTION
## Summary
- Fixed changeset that was incorrectly targeting the private monorepo root package
- Updated changeset to properly target all 12 published packages for patch version bump
- This ensures the release workflow will correctly version the publishable packages

## Test plan
- [x] Verified changeset status shows all published packages will be bumped
- [x] Confirmed monorepo root and private packages are excluded
- [ ] CI will validate the changeset configuration