### PR TITLE
fix: resolve turbo typecheck race condition for TypeScript project references

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "dependsOn": ["build", "lint", "test", "//#arch:check", "//#deps:check"]
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"],
+      "dependsOn": ["^build", "^typecheck"],
       "outputs": [],
       "inputs": [
         "src/**/*.ts",


### PR DESCRIPTION
## Summary
- Fixed flaky build issue where typecheck would randomly fail in CI
- Root cause: TypeScript project references require built `.d.ts` files from dependencies
- Solution: Updated turbo.json to make typecheck depend on `^build` in addition to `^typecheck`

## Technical Details
When using TypeScript project references with `composite: true`, TypeScript needs the referenced projects to be built first to generate their `.d.ts` files and `.tsbuildinfo` files. The previous turbo configuration only had typecheck depending on `^typecheck` (upstream typechecks), creating a race condition where sometimes dependencies were built before typecheck ran (passed) and sometimes they weren't (failed).

This affected 5 packages that use TypeScript references:
- eventsourcing-protocol
- eventsourcing-transport-websocket
- eventsourcing-store-inmemory
- eventsourcing-store-postgres
- eventsourcing-websocket

## Test plan
- [x] Ran `bun turbo run ci --force` locally to verify the fix works
- [x] All tests pass successfully
- [x] No race condition observed
- [x] Cache efficiency maintained (typecheck still depends on `^typecheck` for proper caching)