### PR TITLE
fix: correct repository URLs for npm trusted publishing compatibility

### DIFF
--- a/.changeset/fix-npm-trusted-publishing.md
+++ b/.changeset/fix-npm-trusted-publishing.md
@@ -1,0 +1,18 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+---
+
+Fix repository URL format for npm trusted publishing compatibility
+
+Updated repository URLs in all package.json files to match the exact format required by npm's trusted publishing provenance validation. Changed from lowercase 'codeforbreakfast' to 'CodeForBreakfast' and removed the '.git' suffix to align with the GitHub repository's canonical URL format.

--- a/packages/eventsourcing-aggregates/package.json
+++ b/packages/eventsourcing-aggregates/package.json
@@ -52,7 +52,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-aggregates"
   },
   "bugs": {

--- a/packages/eventsourcing-commands/package.json
+++ b/packages/eventsourcing-commands/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-commands"
   },
   "bugs": {

--- a/packages/eventsourcing-projections/package.json
+++ b/packages/eventsourcing-projections/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-projections"
   },
   "bugs": {

--- a/packages/eventsourcing-protocol/package.json
+++ b/packages/eventsourcing-protocol/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-protocol"
   },
   "bugs": {

--- a/packages/eventsourcing-store-inmemory/package.json
+++ b/packages/eventsourcing-store-inmemory/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-store-inmemory"
   },
   "bugs": {

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -53,7 +53,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-store-postgres"
   },
   "bugs": {

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-store"
   },
   "bugs": {

--- a/packages/eventsourcing-testing-contracts/package.json
+++ b/packages/eventsourcing-testing-contracts/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-testing-contracts"
   },
   "bugs": {

--- a/packages/eventsourcing-transport-inmemory/package.json
+++ b/packages/eventsourcing-transport-inmemory/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-transport-inmemory"
   },
   "bugs": {

--- a/packages/eventsourcing-transport-websocket/package.json
+++ b/packages/eventsourcing-transport-websocket/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-transport-websocket"
   },
   "bugs": {

--- a/packages/eventsourcing-transport/package.json
+++ b/packages/eventsourcing-transport/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-transport"
   },
   "bugs": {

--- a/packages/eventsourcing-websocket/package.json
+++ b/packages/eventsourcing-websocket/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codeforbreakfast/eventsourcing.git",
+    "url": "https://github.com/CodeForBreakfast/eventsourcing",
     "directory": "packages/eventsourcing-websocket"
   },
   "bugs": {


### PR DESCRIPTION
## Summary
- Fixed repository URL format in all package.json files to match npm's trusted publishing requirements
- Changed from lowercase 'codeforbreakfast' to proper case 'CodeForBreakfast'
- Removed '.git' suffix from URLs to align with provenance validation

## Problem
The npm trusted publishing was failing with this error:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "git+https://github.com/codeforbreakfast/eventsourcing.git", 
expected to match "https://github.com/CodeForBreakfast/eventsourcing" from provenance
```

## Solution
Updated all package.json files to use the exact URL format that matches GitHub's canonical repository URL and what the provenance system expects.

## Test Plan
- [x] Updated all package.json files
- [x] Added changeset for the fix
- [ ] PR checks pass
- [ ] npm publishing works with trusted publishing after merge