### PR TITLE
fix(ci): prevent duplicate CI runs on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- CI workflow now only runs on pull requests, not on pushes to main
- Eliminates redundant test runs since all changes already pass CI in PRs
- Saves GitHub Actions minutes and reduces unnecessary build overhead

## Test plan
- [x] Verified CI workflow still triggers on pull requests
- [x] Confirmed push trigger for main branch has been removed
- [x] All existing tests pass locally