### PR TITLE
refactor: simplify arrow functions in pipe operations

### DIFF
--- a/.changeset/clean-pipes-refactor.md
+++ b/.changeset/clean-pipes-refactor.md
@@ -1,0 +1,8 @@
+---
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+---
+
+Simplify arrow functions in pipe operations
+
+Removed unnecessary arrow functions that were just forwarding parameters to other functions, making the code cleaner and more readable. This includes simplifications like changing `(cmd) => sendCommand(cmd)` to just `sendCommand` and `(msg) => transport.publish(msg)` to `transport.publish`.

--- a/packages/eventsourcing-protocol/src/lib/protocol.test.ts
+++ b/packages/eventsourcing-protocol/src/lib/protocol.test.ts
@@ -297,10 +297,7 @@ describe('Protocol Behavior Tests', () => {
               ];
 
               return pipe(
-                Effect.all(
-                  commands.map((cmd) => sendCommand(cmd)),
-                  { concurrency: 'unbounded' }
-                ),
+                Effect.all(commands.map(sendCommand), { concurrency: 'unbounded' }),
                 Effect.tap((results) =>
                   Effect.sync(() => {
                     expect(results).toHaveLength(3);
@@ -696,12 +693,7 @@ describe('Protocol Behavior Tests', () => {
                       )
                     ),
                     // Send commands concurrently while events are being received
-                    pipe(
-                      Effect.all(
-                        commands.map((cmd) => sendCommand(cmd)),
-                        { concurrency: 'unbounded' }
-                      )
-                    ),
+                    pipe(Effect.all(commands.map(sendCommand), { concurrency: 'unbounded' })),
                   ],
                   { concurrency: 'unbounded' }
                 ),
@@ -2260,7 +2252,7 @@ describe('Protocol Behavior Tests', () => {
                 // eslint-disable-next-line functional/prefer-immutable-types
                 cmds: ReadonlyDeep<readonly Command[]>
               ) =>
-                Effect.forEach(cmds, (cmd) => sendCommand(cmd), {
+                Effect.forEach(cmds, sendCommand, {
                   concurrency: 1,
                 });
 

--- a/packages/eventsourcing-testing-contracts/src/lib/transport/client-transport-contract-tests.ts
+++ b/packages/eventsourcing-testing-contracts/src/lib/transport/client-transport-contract-tests.ts
@@ -272,7 +272,7 @@ export const runClientTransportContractTests: TransportTestRunner = (
                   },
                 ];
 
-                return Effect.forEach(messages, (msg) => transport.publish(msg));
+                return Effect.forEach(messages, transport.publish);
               })
             )
           )
@@ -419,7 +419,7 @@ export const runClientTransportContractTests: TransportTestRunner = (
                           { id: '3', type: 'type-a', payload: 'a2' },
                           { id: '4', type: 'type-b', payload: 'b2' },
                         ];
-                        return Effect.forEach(messages, (msg) => transport.publish(msg));
+                        return Effect.forEach(messages, transport.publish);
                       }),
                       Effect.flatMap(() =>
                         Effect.all([Fiber.join(subscription1), Fiber.join(subscription2)])
@@ -500,7 +500,7 @@ export const runClientTransportContractTests: TransportTestRunner = (
                                 payload: { priority: 'high', value: 30 },
                               }, // Should match
                             ];
-                            return Effect.forEach(testMessages, (msg) => transport.publish(msg));
+                            return Effect.forEach(testMessages, transport.publish);
                           }),
                           Effect.flatMap(() => Fiber.join(filteredMessages)),
                           Effect.tap((results) =>


### PR DESCRIPTION
## Summary
- Removed unnecessary arrow functions that just forward parameters to other functions
- Makes code cleaner and more readable by using direct function references
- Affects protocol and testing-contracts packages

## Changes
- Changed `(cmd) => sendCommand(cmd)` to `sendCommand`
- Changed `(msg) => transport.publish(msg)` to `transport.publish`
- Similar simplifications throughout the codebase

## Test plan
- [x] All existing tests pass
- [x] No functional changes, only syntax improvements