### PR TITLE
refactor: remove deprecated Command export and clean up legacy code

### DIFF
--- a/.changeset/clean-deprecated-command-export.md
+++ b/.changeset/clean-deprecated-command-export.md
@@ -1,0 +1,27 @@
+---
+'@codeforbreakfast/eventsourcing-commands': minor
+'@codeforbreakfast/eventsourcing-aggregates': minor
+'@codeforbreakfast/eventsourcing-protocol': minor
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+---
+
+Remove deprecated Command type export and clean up legacy code
+
+**BREAKING CHANGE**: The deprecated `Command` type export has been removed from `@codeforbreakfast/eventsourcing-commands`. Use `WireCommand` instead for transport layer commands.
+
+- Removed deprecated `Command` type export - use `WireCommand` for clarity about transport layer vs domain commands
+- Updated all internal references from `Command` to `WireCommand`
+- Removed migration guides and backward compatibility documentation
+- Cleaned up legacy helper functions and test comments
+
+To update your code:
+
+```typescript
+// Before
+import { Command } from '@codeforbreakfast/eventsourcing-commands';
+
+// After
+import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -467,43 +467,6 @@ const program = pipe(
 4. **Batch writes** when possible to reduce database round-trips
 5. **Consider event archiving** for old events that are rarely accessed
 
-## Migration from Other Event Sourcing Libraries
-
-### From EventStore DB
-
-```typescript
-// Before (EventStore DB)
-const events = await eventStore.readStreamEvents('user-123');
-
-// After (codeforbreakfast) - for historical events only
-const events = await Effect.runPromise(EventStore.read({ streamId: 'user-123' }));
-
-// After (codeforbreakfast) - for historical + live events
-const events = await Effect.runPromise(EventStore.subscribe({ streamId: 'user-123' }));
-```
-
-### From Axon Framework
-
-```typescript
-// Before (Axon)
-@CommandHandler
-public void handle(RegisterUserCommand cmd) {
-  apply(new UserRegisteredEvent(cmd.userId, cmd.email));
-}
-
-// After (codeforbreakfast)
-register: (email) => (state) =>
-  pipe(
-    UserRegistered.make({
-      type: "UserRegistered",
-      email,
-      registeredAt: new Date(),
-    }),
-    Chunk.of,
-    Effect.succeed
-  )
-```
-
 ## License
 
 MIT

--- a/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing-example.ts
@@ -8,7 +8,7 @@ import {
   createCommandProcessingService,
 } from '../index';
 import { Event } from '@codeforbreakfast/eventsourcing-store';
-import { Command } from '@codeforbreakfast/eventsourcing-commands';
+import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
 
 // ============================================================================
 // Example Usage of Command Processing Service
@@ -16,7 +16,7 @@ import { Command } from '@codeforbreakfast/eventsourcing-commands';
 
 // Example: Create a simple command handler
 const userCommandHandler: CommandHandler = {
-  execute: (command: ReadonlyDeep<Command>) =>
+  execute: (command: ReadonlyDeep<WireCommand>) =>
     Effect.succeed([
       {
         position: { streamId: command.target, eventNumber: 1 },
@@ -29,7 +29,7 @@ const userCommandHandler: CommandHandler = {
 
 // Example: Create a command router
 const createRouter = (): CommandRouter => ({
-  route: (command: ReadonlyDeep<Command>) => {
+  route: (command: ReadonlyDeep<WireCommand>) => {
     if (command.target === 'user' && command.name === 'CreateUser') {
       return Effect.succeed(userCommandHandler);
     }
@@ -49,7 +49,7 @@ export const CommandProcessingServiceLive = Layer.effect(
 );
 
 // Example: Usage in application code
-export const processUserCommand = (command: ReadonlyDeep<Command>) =>
+export const processUserCommand = (command: ReadonlyDeep<WireCommand>) =>
   pipe(
     CommandProcessingService,
     Effect.flatMap((service) => service.processCommand(command)),

--- a/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
@@ -11,7 +11,7 @@ import {
   makeInMemoryEventStore,
   InMemoryStore,
 } from '@codeforbreakfast/eventsourcing-store-inmemory';
-import { Command } from '@codeforbreakfast/eventsourcing-commands';
+import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 import { CommandProcessingService } from './commandProcessingService';
 import { CommandHandler, CommandRouter } from './commandHandling';
@@ -25,7 +25,7 @@ import { createCommandProcessingService } from './commandProcessingFactory';
 // Test Data
 // ============================================================================
 
-const testCommand: Command = {
+const testCommand: WireCommand = {
   id: 'cmd-123',
   target: 'user',
   name: 'CreateUser',
@@ -46,7 +46,7 @@ const createTestEvent = (streamId: string, eventNumber: number): Event => ({
 const createMockRouter = (
   handlers: ReadonlyMap<string, CommandHandler> = new Map()
 ): CommandRouter => ({
-  route: (command: Readonly<Command>) => {
+  route: (command: Readonly<WireCommand>) => {
     const key = `${command.target}:${command.name}`;
     const handler = handlers.get(key);
     if (!handler) {
@@ -229,14 +229,14 @@ describe('Command Processing Service', () => {
     ]);
     const router = createMockRouter(handlers);
 
-    const orderCommand: Command = {
+    const orderCommand: WireCommand = {
       ...testCommand,
       id: 'cmd-order-123',
       target: 'order',
       name: 'CreateOrder',
     };
 
-    const updateCommand: Command = {
+    const updateCommand: WireCommand = {
       ...testCommand,
       id: 'cmd-update-123',
       target: 'nonexistent',

--- a/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
@@ -1,16 +1,16 @@
 import { Effect } from 'effect';
 import { Event } from '@codeforbreakfast/eventsourcing-store';
-import { Command } from '@codeforbreakfast/eventsourcing-commands';
+import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 
 export interface CommandHandler {
   readonly execute: (
-    command: Readonly<Command>
+    command: Readonly<WireCommand>
   ) => Effect.Effect<readonly Event[], CommandProcessingError, never>;
 }
 
 export interface CommandRouter {
   readonly route: (
-    command: Readonly<Command>
+    command: Readonly<WireCommand>
   ) => Effect.Effect<CommandHandler, CommandRoutingError, never>;
 }

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
@@ -1,7 +1,7 @@
 import { Effect, pipe, Stream } from 'effect';
 import type { ReadonlyDeep } from 'type-fest';
 import { EventStoreService, beginning, toStreamId } from '@codeforbreakfast/eventsourcing-store';
-import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
+import { WireCommand, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingServiceInterface } from './commandProcessingService';
 import { CommandRouter } from './commandHandling';
 
@@ -11,7 +11,7 @@ export const createCommandProcessingService = (
   pipe(
     EventStoreService,
     Effect.map((eventStore) => ({
-      processCommand: (command: Readonly<Command>) =>
+      processCommand: (command: Readonly<WireCommand>) =>
         pipe(
           router.route(command),
           Effect.flatMap((handler) => handler.execute(command)),

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingService.ts
@@ -1,11 +1,11 @@
 import { Effect } from 'effect';
 import type { ReadonlyDeep } from 'type-fest';
-import { Command, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
+import { WireCommand, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError } from './commandProcessingErrors';
 
 export interface CommandProcessingServiceInterface {
   readonly processCommand: (
-    command: ReadonlyDeep<Command>
+    command: ReadonlyDeep<WireCommand>
   ) => Effect.Effect<CommandResult, CommandProcessingError, never>;
 }
 

--- a/packages/eventsourcing-commands/src/lib/commands.ts
+++ b/packages/eventsourcing-commands/src/lib/commands.ts
@@ -18,12 +18,6 @@ export const WireCommand = Schema.Struct({
 });
 export type WireCommand = typeof WireCommand.Type;
 
-/**
- * Legacy Command export for backward compatibility
- * @deprecated Use WireCommand for clarity
- */
-export type Command = WireCommand;
-
 // ============================================================================
 // Domain Command Types
 // ============================================================================

--- a/packages/eventsourcing-store/src/lib/errors.ts
+++ b/packages/eventsourcing-store/src/lib/errors.ts
@@ -151,15 +151,6 @@ export const isEventSourcingError = (
   ].includes(tag as string);
 };
 
-// Legacy compatibility helpers
-export const resourceError = (resource: string, cause: unknown) =>
-  new EventStoreResourceError({
-    resource,
-    operation: 'access',
-    cause,
-    recoveryHint: 'Check resource availability and permissions',
-  });
-
 // Error creation helpers
 export const eventStoreError = {
   read: (streamId: string | undefined, details: string, cause?: unknown) =>

--- a/packages/eventsourcing-transport-inmemory/README.md
+++ b/packages/eventsourcing-transport-inmemory/README.md
@@ -140,22 +140,6 @@ const connector: InMemoryConnector = (url: string) =>
   Effect<Client.Transport<TransportMessage>, ConnectionError, Scope>;
 ```
 
-## Migration from Legacy API
-
-The old global `InMemoryConnector` has been removed due to TypeScript naming conflicts. Update your code:
-
-```typescript
-// Old (broken)
-import { InMemoryConnector } from '@codeforbreakfast/eventsourcing-transport-inmemory';
-const client = await InMemoryConnector.connect('inmemory://');
-
-// New (pure functional)
-import { InMemoryAcceptor } from '@codeforbreakfast/eventsourcing-transport-inmemory';
-const acceptor = await InMemoryAcceptor.make();
-const server = await acceptor.start();
-const client = await server.connector('inmemory://');
-```
-
 ## Testing
 
 Perfect for contract testing with complete isolation:

--- a/packages/eventsourcing-transport-websocket/src/lib/websocket-transport.test.ts
+++ b/packages/eventsourcing-transport-websocket/src/lib/websocket-transport.test.ts
@@ -145,7 +145,7 @@ const createMockWebSocket = (
       dispatchEvent({ type: 'close', code: code ?? 1000, reason: reason ?? '' });
     },
 
-    // Legacy event handler properties (for compatibility)
+    // Event handler properties
     onopen: null,
     onclose: null,
     onmessage: null,
@@ -290,10 +290,10 @@ describe('WebSocket Transport - WebSocket-Specific Behavior', () => {
 });
 
 // =============================================================================
-// Edge Case Tests (Legacy scenarios for compatibility)
+// Edge Case Tests
 // =============================================================================
 
-describe('WebSocket Transport - Legacy Edge Cases', () => {
+describe('WebSocket Transport - Edge Cases', () => {
   it.scoped('should handle connection to non-existent server', () =>
     pipe(
       // Try to connect to a port that's very unlikely to be in use


### PR DESCRIPTION
## Summary

- Removes the deprecated `Command` type export that was marked for removal
- Cleans up all migration documentation and backwards compatibility code
- Updates all internal references to use `WireCommand` for clarity

## Breaking Changes

**The deprecated `Command` type export has been removed.** Users must update their imports:

```typescript
// Before
import { Command } from '@codeforbreakfast/eventsourcing-commands';

// After  
import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
```

## Changes Made

- ✅ Removed deprecated `Command` type export from `eventsourcing-commands`
- ✅ Updated all package internals to use `WireCommand`
- ✅ Removed migration guides from documentation
- ✅ Cleaned up legacy helper functions and test comments
- ✅ All tests pass
- ✅ All typechecks pass

## Test Plan

- [x] Run `bun run all` - all checks pass
- [x] Verify no references to deprecated `Command` type remain
- [x] Confirm all packages build successfully