### PR TITLE
fix: remove eslint-disable and fix functional violations in websocket tests

### DIFF
--- a/.changeset/brave-kangaroos-hop.md
+++ b/.changeset/brave-kangaroos-hop.md
@@ -1,0 +1,7 @@
+---
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+---
+
+Remove blanket eslint-disable and fix functional programming violations
+
+Replaced file-wide eslint-disable comments with properly typed code that satisfies functional programming rules. The mock WebSocket implementation in tests now uses immutable patterns where possible while maintaining necessary test functionality.


### PR DESCRIPTION
## Summary
- Removed file-wide eslint-disable comments from websocket-transport.test.ts
- Fixed functional programming rule violations by implementing proper readonly types
- Maintained test functionality while satisfying lint rules

## Changes
- Replaced mutable Map operations with immutable patterns for event listeners
- Fixed type declarations to use proper readonly types
- Removed unnecessary Readonly wrappers where types were already immutable

## Test plan
- [x] All websocket transport tests pass (19 passing)
- [x] Lint passes for the package
- [x] Type checking passes