### PR TITLE
feat!: enforce domain-specific event types in command processing

### DIFF
--- a/.changeset/domain-specific-event-types.md
+++ b/.changeset/domain-specific-event-types.md
@@ -1,0 +1,47 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': minor
+'@codeforbreakfast/eventsourcing-store': minor
+---
+
+Enforce domain-specific event types throughout the command processing layer. Command handlers and routers are now generic over your domain event types, preventing accidental use of generic `Event` types with `unknown` data in domain code.
+
+**Breaking Changes:**
+
+- `CommandHandler` and `CommandRouter` are now generic interfaces that require a type parameter
+- `createCommandProcessingService` now requires an event store tag parameter before the router parameter
+- Factory functions with default type parameters have been removed from service tag creation
+
+**Migration:**
+
+Before:
+
+```typescript
+const handler: CommandHandler = {
+  execute: () => Effect.succeed([{ type: 'Created', data: {...} } as Event])
+};
+
+const service = createCommandProcessingService(router);
+```
+
+After:
+
+```typescript
+// 1. Define domain events
+const MyEvent = Schema.Union(Created, Updated);
+type MyEvent = typeof MyEvent.Type;
+
+// 2. Create domain-specific event store tag
+const MyEventStore = Context.GenericTag<EventStore<MyEvent>, EventStore<MyEvent>>('MyEventStore');
+
+// 3. Use typed handlers
+const handler: CommandHandler<MyEvent> = {
+  execute: () => Effect.succeed([{ type: 'Created', data: {...} }])
+};
+
+// 4. Provide event store tag to factory
+const service = createCommandProcessingService(MyEventStore)(router);
+```
+
+The generic `Event` type remains available for serialization boundaries (storage implementations, wire protocol) but should not be used in domain logic.
+
+See ARCHITECTURE.md for detailed design rationale and migration guidance.

--- a/packages/eventsourcing-aggregates/ARCHITECTURE.md
+++ b/packages/eventsourcing-aggregates/ARCHITECTURE.md
@@ -1,0 +1,291 @@
+# Architecture: Command Processing and Type Safety
+
+## Design Philosophy
+
+This package enforces strong typing throughout the domain layer, with generic `Event` types only at serialization boundaries (storage, wire protocol). Domain events are always specific union types, never generic or `unknown`.
+
+## Type Safety Principles
+
+### 1. Domain Events Are Always Specific
+
+**Never use `Event` or `unknown` types in domain logic.**
+
+```typescript
+// ❌ WRONG - Generic Event with unknown data
+const EventStoreService = EventStoreTag<Event>();
+const handler: CommandHandler = {
+  execute: () => Effect.succeed([{ type: 'UserCreated', data: { name: 'John' } } as Event]),
+};
+
+// ✅ CORRECT - Domain-specific event union
+const UserEvent = Schema.Union(UserCreated, UserUpdated, UserDeleted);
+type UserEvent = typeof UserEvent.Type;
+
+const UserEventStore = Context.GenericTag<EventStore<UserEvent>, EventStore<UserEvent>>(
+  'UserEventStore'
+);
+
+const handler: CommandHandler<UserEvent> = {
+  execute: () =>
+    Effect.succeed([{ type: 'UserCreated', data: { name: 'John', email: 'john@example.com' } }]),
+};
+```
+
+### 2. The `Event` Type is for Serialization Boundaries Only
+
+The `Event` type exists in `@codeforbreakfast/eventsourcing-store` with `data: Schema.Unknown`:
+
+```typescript
+export const Event = Schema.Struct({
+  position: EventStreamPosition,
+  type: Schema.String,
+  data: Schema.Unknown, // Generic - for wire/storage only
+  timestamp: Schema.Date,
+});
+```
+
+This type serves two purposes:
+
+1. **Runtime validation** at storage/network boundaries
+2. **Wire protocol** for events crossing system boundaries
+
+It should **never** appear in domain logic, command handlers, or aggregate roots.
+
+### 3. EventStore Services Are Domain-Specific
+
+Each aggregate or bounded context creates its own event store tag with its specific event union:
+
+```typescript
+// In user/events.ts
+const UserCreated = Schema.Struct({
+  type: Schema.Literal('UserCreated'),
+  data: Schema.Struct({
+    name: Schema.String,
+    email: Schema.String,
+  }),
+});
+
+const UserUpdated = Schema.Struct({
+  type: Schema.Literal('UserUpdated'),
+  data: Schema.Struct({
+    name: Schema.String,
+  }),
+});
+
+const UserEvent = Schema.Union(UserCreated, UserUpdated);
+type UserEvent = typeof UserEvent.Type;
+
+// In user/services.ts
+const UserEventStore = Context.GenericTag<EventStore<UserEvent>, EventStore<UserEvent>>(
+  'UserEventStore'
+);
+```
+
+### 4. Command Handlers Are Generic Over Event Types
+
+The command processing layer is fully generic to support any domain's event types:
+
+```typescript
+export interface CommandHandler<TEvent> {
+  readonly execute: (
+    command: Readonly<WireCommand>
+  ) => Effect.Effect<readonly TEvent[], CommandProcessingError, never>;
+}
+
+export interface CommandRouter<TEvent> {
+  readonly route: (
+    command: Readonly<WireCommand>
+  ) => Effect.Effect<CommandHandler<TEvent>, CommandRoutingError, never>;
+}
+```
+
+This allows each domain to have strongly-typed command handlers:
+
+```typescript
+const createUser: CommandHandler<UserEvent> = {
+  execute: (command) =>
+    Effect.succeed([
+      {
+        type: 'UserCreated' as const,
+        data: {
+          name: command.payload.name,
+          email: command.payload.email,
+        },
+      },
+    ]),
+};
+```
+
+## Command Processing Factory
+
+The `createCommandProcessingService` factory is generic and requires both:
+
+1. A domain-specific event store tag
+2. A domain-specific command router
+
+```typescript
+export const createCommandProcessingService = <TEvent>(
+  eventStoreTag: Readonly<Context.Tag<EventStore<TEvent>, EventStore<TEvent>>>
+) => (router: ReadonlyDeep<CommandRouter<TEvent>>) => // ...
+```
+
+**Usage pattern:**
+
+```typescript
+// Define domain events
+const OrderEvent = Schema.Union(OrderCreated, OrderShipped, OrderCancelled);
+
+// Create domain-specific event store tag
+const OrderEventStore = Context.GenericTag<EventStore<OrderEvent>, EventStore<OrderEvent>>(
+  'OrderEventStore'
+);
+
+// Create router with domain-specific handlers
+const createOrderRouter = (): CommandRouter<OrderEvent> => ({
+  route: (command) => {
+    // Return handlers that produce OrderEvent[]
+  },
+});
+
+// Wire it all together
+const OrderCommandProcessingService = Layer.effect(
+  CommandProcessingService,
+  createCommandProcessingService(OrderEventStore)(createOrderRouter())
+);
+```
+
+## Why This Pattern?
+
+### Type Safety Guarantees
+
+1. **Compile-time verification**: TypeScript ensures handlers can only produce events from the domain union
+2. **No accidental `unknown`**: Impossible to accidentally use generic events in domain logic
+3. **Refactoring safety**: Changing event schemas causes compile errors in all handlers
+4. **IDE autocomplete**: Full type information for event data in handlers and aggregates
+
+### Separation of Concerns
+
+1. **Domain layer**: Works with typed domain events (`UserEvent`, `OrderEvent`)
+2. **Infrastructure layer**: Handles serialization with generic `Event` type
+3. **Clear boundaries**: The transition point between typed/untyped is explicit (event store implementation)
+
+### Storage Independence
+
+The event store implementation (Postgres, in-memory, etc.) uses the generic `Event` type for storage but transforms to/from domain events at the boundary:
+
+```typescript
+// In postgres event store implementation
+export const makePostgresEventStore = <TEvent>(
+  schema: Schema.Schema<TEvent, unknown>
+): EventStore<TEvent> => ({
+  append: (position) =>
+    Sink.mapInputEffect((event: TEvent) =>
+      pipe(
+        // Encode domain event to storage Event
+        event,
+        Schema.encode(schema),
+        Effect.map((encoded) => ({
+          type: encoded.type,
+          data: encoded.data, // now unknown
+          timestamp: new Date(),
+          position,
+        }))
+      )
+    ),
+
+  read: (from) =>
+    Stream.flatMap((storageEvent: Event) =>
+      // Decode storage Event to domain event
+      Schema.decode(schema)(storageEvent)
+    ),
+});
+```
+
+## Comparison to Original Design
+
+### What Changed
+
+**Before (over-engineered):**
+
+- Factory functions (`EventStore<TEvent>()`) that invited default type parameters
+- Generic `Event` type used throughout domain layer
+- Command handlers returned `Event[]` with `data: unknown`
+- Lost type safety at command boundary
+
+**After (domain-specific types):**
+
+- Direct tag creation per domain: `Context.GenericTag<EventStore<UserEvent>, ...>`
+- Domain-specific event unions (`UserEvent`, `OrderEvent`)
+- Generic command processing layer that works with any event type
+- Full type safety from command to storage
+
+### What Stayed the Same
+
+- `Event` type still exists for wire/storage boundaries
+- Event stores still use the same `EventStore<TEvent>` interface
+- Command processing architecture unchanged
+- Effect-based composition patterns
+
+## Guidelines for New Code
+
+### ✅ DO
+
+- Create domain-specific event unions for each aggregate
+- Create named event store tags per domain (`UserEventStore`, `OrderEventStore`)
+- Use `CommandHandler<YourEvent>` and `CommandRouter<YourEvent>`
+- Keep `Event` type at storage/network boundaries only
+
+### ❌ DON'T
+
+- Use `EventStore<Event>()` or `EventStore<unknown>()`
+- Use default type parameters on event store factories
+- Return generic `Event[]` from command handlers
+- Use `data: Schema.Unknown` in domain event schemas
+
+## Testing Strategy
+
+Tests should use domain-specific events:
+
+```typescript
+// Define test domain events
+const TestEvent = Schema.Union(
+  Schema.Struct({
+    type: Schema.Literal('TestCreated'),
+    data: Schema.Struct({ id: Schema.String }),
+  }),
+  Schema.Struct({
+    type: Schema.Literal('TestUpdated'),
+    data: Schema.Struct({ value: Schema.Number }),
+  })
+);
+
+// Create test event store
+const TestEventStore = Context.GenericTag<
+  EventStore<typeof TestEvent.Type>,
+  EventStore<typeof TestEvent.Type>
+>('TestEventStore');
+
+// Create handlers and routers with TestEvent
+const testHandler: CommandHandler<typeof TestEvent.Type> = {
+  execute: () => Effect.succeed([{ type: 'TestCreated', data: { id: 'test-123' } }]),
+};
+```
+
+## Migration Path
+
+To migrate existing code to this pattern:
+
+1. **Define domain event union**: Create `Schema.Union` of all events for your aggregate
+2. **Create domain-specific tag**: Replace factory calls with direct `Context.GenericTag` creation
+3. **Update command handlers**: Add `<YourEvent>` type parameter to handlers and routers
+4. **Update factory usage**: Pass event store tag to `createCommandProcessingService`
+5. **Remove `Event` imports**: Delete any imports of generic `Event` from domain code
+
+## Related Patterns
+
+This architecture supports and enables:
+
+- **Aggregate Root Pattern**: Each aggregate has its own event union and event store tag
+- **Bounded Contexts**: Different domains have different event types with no mixing
+- **CQRS**: Read models can subscribe to specific event types with full type information
+- **Event Upcasting**: Type-safe transformation from old event schemas to new ones

--- a/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandHandling.ts
@@ -1,16 +1,15 @@
 import { Effect } from 'effect';
-import { Event } from '@codeforbreakfast/eventsourcing-store';
 import { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandProcessingError, CommandRoutingError } from './commandProcessingErrors';
 
-export interface CommandHandler {
+export interface CommandHandler<TEvent> {
   readonly execute: (
     command: Readonly<WireCommand>
-  ) => Effect.Effect<readonly Event[], CommandProcessingError, never>;
+  ) => Effect.Effect<readonly TEvent[], CommandProcessingError, never>;
 }
 
-export interface CommandRouter {
+export interface CommandRouter<TEvent> {
   readonly route: (
     command: Readonly<WireCommand>
-  ) => Effect.Effect<CommandHandler, CommandRoutingError, never>;
+  ) => Effect.Effect<CommandHandler<TEvent>, CommandRoutingError, never>;
 }

--- a/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandProcessingFactory.ts
@@ -1,45 +1,45 @@
-import { Effect, pipe, Stream } from 'effect';
+import { Effect, pipe, Stream, Context } from 'effect';
 import type { ReadonlyDeep } from 'type-fest';
-import { EventStoreTag, beginning, toStreamId } from '@codeforbreakfast/eventsourcing-store';
+import { type EventStore, beginning, toStreamId } from '@codeforbreakfast/eventsourcing-store';
 import { WireCommand, CommandResult } from '@codeforbreakfast/eventsourcing-commands';
 import { CommandRouter } from './commandHandling';
 
-const EventStoreService = EventStoreTag<unknown>();
-
-export const createCommandProcessingService = (router: ReadonlyDeep<CommandRouter>) =>
-  pipe(
-    EventStoreService,
-    Effect.map((eventStore) => ({
-      processCommand: (command: Readonly<WireCommand>) =>
-        pipe(
-          router.route(command),
-          Effect.flatMap((handler) => handler.execute(command)),
-          Effect.flatMap((events) =>
-            pipe(
-              toStreamId(command.target),
-              Effect.flatMap(beginning),
-              Effect.flatMap((position) =>
-                pipe(Stream.fromIterable(events), Stream.run(eventStore.append(position)))
+export const createCommandProcessingService =
+  <TEvent>(eventStoreTag: Readonly<Context.Tag<EventStore<TEvent>, EventStore<TEvent>>>) =>
+  (router: ReadonlyDeep<CommandRouter<TEvent>>) =>
+    pipe(
+      eventStoreTag,
+      Effect.map((eventStore) => ({
+        processCommand: (command: Readonly<WireCommand>) =>
+          pipe(
+            router.route(command),
+            Effect.flatMap((handler) => handler.execute(command)),
+            Effect.flatMap((events) =>
+              pipe(
+                toStreamId(command.target),
+                Effect.flatMap(beginning),
+                Effect.flatMap((position) =>
+                  pipe(Stream.fromIterable(events), Stream.run(eventStore.append(position)))
+                )
               )
+            ),
+            Effect.map(
+              (position): CommandResult => ({
+                _tag: 'Success',
+                position,
+              })
+            ),
+            Effect.catchAll(
+              (error): Effect.Effect<CommandResult, never, never> =>
+                Effect.succeed({
+                  _tag: 'Failure',
+                  error: {
+                    _tag: 'UnknownError',
+                    commandId: command.id,
+                    message: String(error),
+                  },
+                })
             )
           ),
-          Effect.map(
-            (position): CommandResult => ({
-              _tag: 'Success',
-              position,
-            })
-          ),
-          Effect.catchAll(
-            (error): Effect.Effect<CommandResult, never, never> =>
-              Effect.succeed({
-                _tag: 'Failure',
-                error: {
-                  _tag: 'UnknownError',
-                  commandId: command.id,
-                  message: String(error),
-                },
-              })
-          )
-        ),
-    }))
-  );
+      }))
+    );

--- a/packages/eventsourcing-store/README.md
+++ b/packages/eventsourcing-store/README.md
@@ -170,6 +170,50 @@ interface EventStreamPosition {
 }
 ```
 
+### Creating Event Store Service Tags
+
+**⚠️ IMPORTANT: Always create domain-specific event store tags**
+
+Each aggregate or bounded context should create its own typed event store tag using `Context.GenericTag`:
+
+```typescript
+import { Schema, Context } from 'effect';
+import { type EventStore } from '@codeforbreakfast/eventsourcing-store';
+
+// 1. Define your domain events
+const UserCreated = Schema.Struct({
+  type: Schema.Literal('UserCreated'),
+  data: Schema.Struct({
+    name: Schema.String,
+    email: Schema.String,
+  }),
+});
+
+const UserUpdated = Schema.Struct({
+  type: Schema.Literal('UserUpdated'),
+  data: Schema.Struct({
+    email: Schema.String,
+  }),
+});
+
+// 2. Create event union
+const UserEvent = Schema.Union(UserCreated, UserUpdated);
+type UserEvent = typeof UserEvent.Type;
+
+// 3. Create domain-specific event store tag
+export const UserEventStore = Context.GenericTag<EventStore<UserEvent>, EventStore<UserEvent>>(
+  'UserEventStore'
+);
+```
+
+**Do NOT use:**
+
+- Generic `Event` type in domain code
+- Factory functions with default type parameters
+- `EventStore<unknown>()` or `EventStore<Event>()`
+
+The generic `Event` type exists only for serialization boundaries (storage implementations, wire protocol). Your domain code should always use specific event union types.
+
 ## Available Implementations
 
 This package provides core interfaces and types. For concrete implementations, use:


### PR DESCRIPTION
## Summary

Enforces strong typing throughout the command processing layer by making command handlers and event stores generic over domain-specific event unions. This prevents accidental use of generic `Event` types with `unknown` data in domain code.

## Changes

- Made `CommandHandler<TEvent>` and `CommandRouter<TEvent>` generic over event types
- Updated `createCommandProcessingService` to require an event store tag parameter
- Removed default type parameters from service tag factories
- Added comprehensive architecture documentation (ARCHITECTURE.md)
- Updated READMEs with type safety guidelines and migration examples

## Breaking Changes

Command handlers, routers, and the command processing factory now require explicit type parameters. See changeset for migration guide.

## Type Safety Benefits

- Compile-time verification that handlers only produce events from domain unions
- No accidental use of `unknown` types
- Full IDE autocomplete for event data
- Refactoring safety - schema changes cause compile errors

The generic `Event` type remains for serialization boundaries (storage, wire) only.

## Test Plan

- ✅ All existing tests pass
- ✅ Tests updated to use domain-specific `TestEvent` union
- ✅ Build and lint checks pass