### PR TITLE
refactor: use immutable collections from Effect

### DIFF
--- a/.changeset/immutable-collections-refactor.md
+++ b/.changeset/immutable-collections-refactor.md
@@ -1,0 +1,8 @@
+---
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+---
+
+Internal refactoring to use immutable collections from Effect
+
+Replaced mutable data structures with Effect's immutable HashSet and Chunk collections for better functional programming practices. This is an internal implementation change with no impact on the public API or behavior.


### PR DESCRIPTION
## Summary

Replace mutable data structures with Effect's immutable collections (HashSet and Chunk) to eliminate state mutations and improve functional programming practices.

## Changes

- Replace native `Set` with `HashSet` in production code
- Replace `array.push()` with `Ref<Chunk>` in test files
- All changes are internal with no API impact

## Affected Packages

- `@codeforbreakfast/eventsourcing-store-postgres`
- `@codeforbreakfast/eventsourcing-transport-websocket`
- `@codeforbreakfast/eventsourcing-store` (tests only)
- `@codeforbreakfast/eventsourcing-testing-contracts` (tests only)

## Test Plan

- [x] All existing tests pass
- [x] Lint and typecheck pass
- [x] No breaking changes to public API