### PR TITLE
refactor(aggregates): simplify command processing with Effect.all

### DIFF
--- a/.changeset/simplify-command-processing.md
+++ b/.changeset/simplify-command-processing.md
@@ -1,0 +1,5 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': patch
+---
+
+Improved readability of command processing by reducing nested pipe calls. The command processing factory now uses Effect.all to run independent effects in parallel with descriptive names, making the code flow clearer while maintaining identical behavior.


### PR DESCRIPTION
## Summary

Refactored command processing factory to improve readability by reducing deeply nested `pipe` calls.

## Changes

- Used `Effect.all` with named fields to run independent effects in parallel
- Eliminated 3 levels of nested pipes
- Named intermediate values for clarity: `handler`, `streamId`, `events`, `position`
- Removed unused `pipe` import

## Testing

- ✅ All existing tests pass
- ✅ Type checking passes
- ✅ Linting passes (respects no-Effect.gen rule)
- ✅ No behavioral changes

## Impact

This is a pure refactoring - identical behavior, improved readability.