### PR TITLE
refactor(lint): deduplicate and improve ESLint configuration

### DIFF
--- a/.changeset/deduplicate-eslint-config.md
+++ b/.changeset/deduplicate-eslint-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improve ESLint configuration maintainability by extracting shared rules into named constants. All plugin configurations, language options, rule sets, and syntax restrictions are now defined once and referenced throughout, making it easier to understand and modify linting rules consistently across the codebase. Test files now also enforce simple pipe patterns to maintain code quality standards.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -219,6 +219,8 @@ export default [
       'functional/immutable-data': 'off',
       // Enforce readonly arrays/tuples in tests
       'functional/prefer-readonly-type': 'error',
+      // Enforce functional patterns - no loops in tests either
+      'functional/no-loop-statements': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -245,14 +245,7 @@ export default [
   {
     name: 'simple-pipes',
     files: ['packages/**/*.ts', 'packages/**/*.tsx'],
-    ignores: [
-      '**/*.test.ts',
-      '**/*.test.tsx',
-      '**/*.spec.ts',
-      '**/*.spec.tsx',
-      '**/buntest/**',
-      '**/eventsourcing-testing-contracts/**',
-    ],
+    ignores: ['**/buntest/**', '**/eventsourcing-testing-contracts/**'],
     languageOptions: commonLanguageOptions,
     plugins: {
       '@typescript-eslint': typescript,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -284,11 +284,17 @@ export default [
       '**/*test*.tsx',
       '**/testing/**/*.ts',
     ],
+    ignores: ['**/buntest/**'],
     languageOptions: commonLanguageOptions,
     plugins: commonPluginsWithFunctional,
     rules: {
       ...testFileImportRestrictions,
-      'no-restricted-syntax': ['error', ...effectSyntaxRestrictions, ...testSyntaxRestrictions],
+      'no-restricted-syntax': [
+        'error',
+        ...effectSyntaxRestrictions,
+        ...testSyntaxRestrictions,
+        ...simplePipeSyntaxRestrictions,
+      ],
       ...testFunctionalRules,
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -195,7 +195,10 @@ export default [
       '**/testing/**/*.ts',
     ],
     languageOptions: commonLanguageOptions,
-    plugins: commonPlugins,
+    plugins: {
+      ...commonPlugins,
+      functional: functionalPlugin,
+    },
     rules: {
       'no-restricted-imports': [
         'error',
@@ -214,6 +217,8 @@ export default [
       'functional/no-let': 'off',
       // Relax immutability for test data manipulation
       'functional/immutable-data': 'off',
+      // Enforce readonly arrays/tuples in tests
+      'functional/prefer-readonly-type': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,10 +14,31 @@ const commonLanguageOptions = {
   },
 };
 
+const commonLanguageOptionsWithProject = {
+  ...commonLanguageOptions,
+  parserOptions: {
+    ...commonLanguageOptions.parserOptions,
+    project: true,
+  },
+};
+
 const commonPlugins = {
   '@typescript-eslint': typescript,
   'unused-imports': unusedImports,
   import: importPlugin,
+};
+
+const commonPluginsWithFunctional = {
+  ...commonPlugins,
+  functional: functionalPlugin,
+};
+
+const typescriptPlugin = {
+  '@typescript-eslint': typescript,
+};
+
+const functionalPluginOnly = {
+  functional: functionalPlugin,
 };
 
 // Common Effect-related syntax restrictions
@@ -61,109 +82,180 @@ const testSyntaxRestrictions = [
   },
 ];
 
+// Simple pipe syntax restrictions
+const simplePipeSyntaxRestrictions = [
+  {
+    selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="pipe"]',
+    message:
+      'Method-based .pipe() is forbidden. Use the standalone pipe() function instead for consistency.',
+  },
+  {
+    selector:
+      'CallExpression[callee.type="CallExpression"][callee.callee.type="MemberExpression"]:not([callee.callee.object.name="Context"][callee.callee.property.name="Tag"]):not([callee.callee.object.name="Context"][callee.callee.property.name="GenericTag"]):not([callee.callee.object.name="Effect"][callee.callee.property.name="Tag"]):not([callee.callee.object.name="Data"][callee.callee.property.name="TaggedError"]):not([callee.callee.object.name="Schema"][callee.callee.property.name="Class"])',
+    message:
+      'Curried function calls are forbidden. Use pipe() instead. Example: pipe(data, Schema.decodeUnknown(schema)) instead of Schema.decodeUnknown(schema)(data)',
+  },
+  {
+    selector:
+      'CallExpression[callee.type="Identifier"][callee.name="pipe"] CallExpression[callee.type="Identifier"][callee.name="pipe"]',
+    message:
+      'Nested pipe() calls are forbidden. Extract the inner pipe to a separate named function that returns an Effect.',
+  },
+  {
+    selector:
+      'ArrowFunctionExpression:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
+    message:
+      'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
+  },
+  {
+    selector:
+      'FunctionDeclaration:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
+    message:
+      'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
+  },
+  {
+    selector:
+      'FunctionExpression:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
+    message:
+      'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
+  },
+];
+
+// Common functional immutability rules
+const functionalImmutabilityRules = {
+  'functional/prefer-immutable-types': [
+    'error',
+    {
+      enforcement: 'ReadonlyShallow',
+      ignoreInferredTypes: true,
+      ignoreTypePattern: [
+        // Effect types are immutable-by-contract but contain internal mutable state
+        '^Ref\\.Ref<.*>$',
+        '^Queue\\.Queue<.*>$',
+        '^HashMap\\.HashMap<.*>$',
+        '^HashSet\\.HashSet<.*>$',
+        '^Stream\\.Stream<.*>$',
+        '^PubSub\\.PubSub<.*>$',
+        // Bun types wrapped in ReadonlyDeep are treated as immutable at boundaries
+        'ServerWebSocket<.*>$',
+        // Built-in types wrapped in ReadonlyDeep are treated as immutable
+        '^ReadonlyDeep<Date>$',
+      ],
+      parameters: {
+        // Use ReadonlyShallow for parameters because Effect types contain internal
+        // mutable state. ReadonlyShallow ensures readonly wrappers while allowing
+        // Effect types within the structure.
+        enforcement: 'ReadonlyShallow',
+      },
+    },
+  ],
+  'functional/type-declaration-immutability': [
+    'error',
+    {
+      rules: [
+        {
+          identifiers: ['I.+'],
+          immutability: 'ReadonlyDeep',
+          comparator: 'AtLeast',
+        },
+      ],
+      ignoreIdentifierPattern: [
+        // Interfaces/types containing Effect/Schema types which are immutable-by-contract
+        '.*Internal.*',
+        '.*State',
+        '.*Store',
+        'Incoming.*',
+      ],
+    },
+  ],
+  'functional/no-let': 'error',
+  'functional/immutable-data': [
+    'error',
+    {
+      ignoreImmediateMutation: true,
+      ignoreClasses: true,
+      ignoreAccessorPattern: ['draft.**', '**.draft'],
+    },
+  ],
+  'functional/prefer-readonly-type': 'error',
+  'functional/no-method-signature': 'off',
+  'functional/no-mixed-types': 'off',
+  'functional/no-return-void': 'off',
+  'functional/functional-parameters': 'off',
+  'functional/no-expression-statements': 'off',
+  'functional/no-conditional-statements': 'off',
+  'functional/no-loop-statements': 'error',
+};
+
+// Test-specific functional rules (more relaxed)
+const testFunctionalRules = {
+  'functional/no-let': 'off',
+  'functional/immutable-data': 'off',
+  'functional/prefer-readonly-type': 'error',
+  'functional/no-loop-statements': 'error',
+};
+
+// Testing contracts exception rules (all disabled)
+const testingContractsExceptionRules = {
+  'functional/prefer-immutable-types': 'off',
+  'functional/prefer-readonly-type': 'off',
+  'functional/no-let': 'off',
+  'functional/immutable-data': 'off',
+  'functional/type-declaration-immutability': 'off',
+  'no-restricted-imports': 'off',
+  'no-restricted-syntax': 'off',
+};
+
+// Common TypeScript rules
+const typescriptBaseRules = {
+  ...typescript.configs['recommended'].rules,
+  ...prettier.rules,
+  'unused-imports/no-unused-imports': 'error',
+  '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  '@typescript-eslint/explicit-function-return-type': 'off',
+  '@typescript-eslint/explicit-module-boundary-types': 'off',
+  '@typescript-eslint/no-explicit-any': 'error',
+  'import/extensions': [
+    'error',
+    'never',
+    {
+      js: 'never',
+      ts: 'never',
+      tsx: 'never',
+    },
+  ],
+};
+
+// Test file imports restrictions
+const testFileImportRestrictions = {
+  'no-restricted-imports': [
+    'error',
+    {
+      patterns: [
+        {
+          group: ['bun:test'],
+          message:
+            'Test files should prefer "@codeforbreakfast/buntest" over "bun:test" for better Effect integration. Use buntest unless you specifically need bun:test features.',
+        },
+      ],
+    },
+  ],
+};
+
 export default [
   {
     name: 'functional-immutability',
     files: ['**/*.ts', '**/*.tsx'],
-    languageOptions: {
-      ...commonLanguageOptions,
-      parserOptions: {
-        ...commonLanguageOptions.parserOptions,
-        project: true,
-      },
-    },
-    plugins: {
-      functional: functionalPlugin,
-    },
-    rules: {
-      // Immutability rules
-      'functional/prefer-immutable-types': [
-        'error',
-        {
-          enforcement: 'ReadonlyShallow',
-          ignoreInferredTypes: true,
-          ignoreTypePattern: [
-            // Effect types are immutable-by-contract but contain internal mutable state
-            '^Ref\\.Ref<.*>$',
-            '^Queue\\.Queue<.*>$',
-            '^HashMap\\.HashMap<.*>$',
-            '^HashSet\\.HashSet<.*>$',
-            '^Stream\\.Stream<.*>$',
-            '^PubSub\\.PubSub<.*>$',
-            // Bun types wrapped in ReadonlyDeep are treated as immutable at boundaries
-            'ServerWebSocket<.*>$',
-            // Built-in types wrapped in ReadonlyDeep are treated as immutable
-            '^ReadonlyDeep<Date>$',
-          ],
-          parameters: {
-            // Use ReadonlyShallow for parameters because Effect types contain internal
-            // mutable state. ReadonlyShallow ensures readonly wrappers while allowing
-            // Effect types within the structure.
-            enforcement: 'ReadonlyShallow',
-          },
-        },
-      ],
-      'functional/type-declaration-immutability': [
-        'error',
-        {
-          rules: [
-            {
-              identifiers: ['I.+'],
-              immutability: 'ReadonlyDeep',
-              comparator: 'AtLeast',
-            },
-          ],
-          ignoreIdentifierPattern: [
-            // Interfaces/types containing Effect/Schema types which are immutable-by-contract
-            '.*Internal.*',
-            '.*State',
-            '.*Store',
-            'Incoming.*',
-          ],
-        },
-      ],
-      'functional/no-let': 'error',
-      'functional/immutable-data': [
-        'error',
-        {
-          ignoreImmediateMutation: true,
-          ignoreClasses: true,
-          ignoreAccessorPattern: ['draft.**', '**.draft'],
-        },
-      ],
-      'functional/prefer-readonly-type': 'error',
-      'functional/no-method-signature': 'off', // Allow method signatures for Effect services
-      'functional/no-mixed-types': 'off', // Allow mixed types for Effect services
-      'functional/no-return-void': 'off', // Allow void returns for Effect
-      'functional/functional-parameters': 'off', // Too strict for current codebase
-      'functional/no-expression-statements': 'off', // Too restrictive
-      'functional/no-conditional-statements': 'off', // Would require full rewrite
-      'functional/no-loop-statements': 'error',
-    },
+    languageOptions: commonLanguageOptionsWithProject,
+    plugins: functionalPluginOnly,
+    rules: functionalImmutabilityRules,
   },
   {
     name: 'typescript-base',
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: commonLanguageOptions,
     plugins: commonPlugins,
-    rules: {
-      ...typescript.configs['recommended'].rules,
-      ...prettier.rules,
-      'unused-imports/no-unused-imports': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'error',
-      'import/extensions': [
-        'error',
-        'never',
-        {
-          js: 'never',
-          ts: 'never',
-          tsx: 'never',
-        },
-      ],
-    },
+    rules: typescriptBaseRules,
   },
   {
     name: 'effect-coding-standards',
@@ -176,9 +268,7 @@ export default [
       '**/*.spec.tsx',
     ],
     languageOptions: commonLanguageOptions,
-    plugins: {
-      '@typescript-eslint': typescript,
-    },
+    plugins: typescriptPlugin,
     rules: {
       'no-restricted-syntax': ['error', ...effectSyntaxRestrictions],
     },
@@ -195,32 +285,11 @@ export default [
       '**/testing/**/*.ts',
     ],
     languageOptions: commonLanguageOptions,
-    plugins: {
-      ...commonPlugins,
-      functional: functionalPlugin,
-    },
+    plugins: commonPluginsWithFunctional,
     rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['bun:test'],
-              message:
-                'Test files should prefer "@codeforbreakfast/buntest" over "bun:test" for better Effect integration. Use buntest unless you specifically need bun:test features.',
-            },
-          ],
-        },
-      ],
+      ...testFileImportRestrictions,
       'no-restricted-syntax': ['error', ...effectSyntaxRestrictions, ...testSyntaxRestrictions],
-      // Allow let in tests for setup/teardown patterns
-      'functional/no-let': 'off',
-      // Relax immutability for test data manipulation
-      'functional/immutable-data': 'off',
-      // Enforce readonly arrays/tuples in tests
-      'functional/prefer-readonly-type': 'error',
-      // Enforce functional patterns - no loops in tests either
-      'functional/no-loop-statements': 'error',
+      ...testFunctionalRules,
     },
   },
   {
@@ -230,67 +299,17 @@ export default [
       '**/eventsourcing-testing-contracts/**/*.tsx',
     ],
     languageOptions: commonLanguageOptions,
-    plugins: {
-      functional: functionalPlugin,
-    },
-    rules: {
-      // Disable immutability rules for testing contract files
-      'functional/prefer-immutable-types': 'off',
-      'functional/prefer-readonly-type': 'off',
-      'functional/no-let': 'off',
-      'functional/immutable-data': 'off',
-      'functional/type-declaration-immutability': 'off',
-      'no-restricted-imports': 'off',
-      'no-restricted-syntax': 'off',
-    },
+    plugins: functionalPluginOnly,
+    rules: testingContractsExceptionRules,
   },
   {
     name: 'simple-pipes',
     files: ['packages/**/*.ts', 'packages/**/*.tsx'],
     ignores: ['**/buntest/**', '**/eventsourcing-testing-contracts/**'],
     languageOptions: commonLanguageOptions,
-    plugins: {
-      '@typescript-eslint': typescript,
-    },
+    plugins: typescriptPlugin,
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'CallExpression[callee.type="MemberExpression"][callee.property.name="pipe"]',
-          message:
-            'Method-based .pipe() is forbidden. Use the standalone pipe() function instead for consistency.',
-        },
-        {
-          selector:
-            'CallExpression[callee.type="CallExpression"][callee.callee.type="MemberExpression"]:not([callee.callee.object.name="Context"][callee.callee.property.name="Tag"]):not([callee.callee.object.name="Context"][callee.callee.property.name="GenericTag"]):not([callee.callee.object.name="Effect"][callee.callee.property.name="Tag"]):not([callee.callee.object.name="Data"][callee.callee.property.name="TaggedError"]):not([callee.callee.object.name="Schema"][callee.callee.property.name="Class"])',
-          message:
-            'Curried function calls are forbidden. Use pipe() instead. Example: pipe(data, Schema.decodeUnknown(schema)) instead of Schema.decodeUnknown(schema)(data)',
-        },
-        {
-          selector:
-            'CallExpression[callee.type="Identifier"][callee.name="pipe"] CallExpression[callee.type="Identifier"][callee.name="pipe"]',
-          message:
-            'Nested pipe() calls are forbidden. Extract the inner pipe to a separate named function that returns an Effect.',
-        },
-        {
-          selector:
-            'ArrowFunctionExpression:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
-          message:
-            'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
-        },
-        {
-          selector:
-            'FunctionDeclaration:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
-          message:
-            'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
-        },
-        {
-          selector:
-            'FunctionExpression:has(CallExpression[callee.type="Identifier"][callee.name="pipe"]) CallExpression[callee.type="Identifier"][callee.name="pipe"] ~ CallExpression[callee.type="Identifier"][callee.name="pipe"]',
-          message:
-            'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
-        },
-      ],
+      'no-restricted-syntax': ['error', ...simplePipeSyntaxRestrictions],
     },
   },
   {

--- a/packages/eventsourcing-commands/src/lib/command-registry.test.ts
+++ b/packages/eventsourcing-commands/src/lib/command-registry.test.ts
@@ -7,8 +7,8 @@ import { makeCommandRegistry } from './command-registry';
 
 describe('Command Registry', () => {
   const UserPayload = Schema.Struct({
-    email: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
-    name: Schema.String.pipe(Schema.minLength(1)),
+    email: pipe(Schema.String, Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
+    name: pipe(Schema.String, Schema.minLength(1)),
   });
 
   it.effect('should register and dispatch commands successfully', () => {
@@ -18,7 +18,8 @@ describe('Command Registry', () => {
     type Commands = CommandFromDefinitions<typeof commands>;
 
     const commandMatcher = (command: ReadonlyDeep<Commands>) =>
-      Match.value(command).pipe(
+      pipe(
+        Match.value(command),
         Match.when({ name: 'CreateUser' }, () =>
           Effect.succeed({
             _tag: 'Success' as const,
@@ -62,7 +63,8 @@ describe('Command Registry', () => {
     type Commands = CommandFromDefinitions<typeof commands>;
 
     const commandMatcher = (command: ReadonlyDeep<Commands>) =>
-      Match.value(command).pipe(
+      pipe(
+        Match.value(command),
         Match.when({ name: 'CreateUser' }, () =>
           Effect.succeed({
             _tag: 'Success' as const,
@@ -109,7 +111,8 @@ describe('Command Registry', () => {
     type Commands = CommandFromDefinitions<typeof commands>;
 
     const commandMatcher = (command: ReadonlyDeep<Commands>) =>
-      Match.value(command).pipe(
+      pipe(
+        Match.value(command),
         Match.when({ name: 'CreateUser' }, () =>
           Effect.succeed({
             _tag: 'Success' as const,
@@ -152,7 +155,8 @@ describe('Command Registry', () => {
     type Commands = CommandFromDefinitions<typeof commands>;
 
     const commandMatcher = (command: ReadonlyDeep<Commands>) =>
-      Match.value(command).pipe(
+      pipe(
+        Match.value(command),
         Match.when({ name: 'CreateUser' }, () => Effect.die(new Error('Something went wrong'))),
         Match.exhaustive
       );
@@ -184,7 +188,7 @@ describe('Command Registry', () => {
 
   it.effect('should support multiple command types', () => {
     const UpdateEmailPayload = Schema.Struct({
-      newEmail: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
+      newEmail: pipe(Schema.String, Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
     });
 
     const createUserCommand = defineCommand('CreateUser', UserPayload);
@@ -194,7 +198,8 @@ describe('Command Registry', () => {
     type Commands = CommandFromDefinitions<typeof commands>;
 
     const commandMatcher = (command: ReadonlyDeep<Commands>) =>
-      Match.value(command).pipe(
+      pipe(
+        Match.value(command),
         Match.when({ name: 'CreateUser' }, () =>
           Effect.succeed({
             _tag: 'Success' as const,

--- a/packages/eventsourcing-commands/src/lib/commands.test.ts
+++ b/packages/eventsourcing-commands/src/lib/commands.test.ts
@@ -12,7 +12,7 @@ describe('Wire Commands', () => {
         payload: { email: 'test@example.com' },
       };
 
-      const result = Schema.decodeUnknownEither(WireCommand)(validCommand);
+      const result = pipe(validCommand, Schema.decodeUnknownEither(WireCommand));
       expect(result._tag).toBe('Right');
     });
 
@@ -24,7 +24,7 @@ describe('Wire Commands', () => {
         payload: { email: 'test@example.com' },
       };
 
-      const result = Schema.decodeUnknownEither(WireCommand)(invalidCommand);
+      const result = pipe(invalidCommand, Schema.decodeUnknownEither(WireCommand));
       expect(result._tag).toBe('Left');
     });
 
@@ -40,7 +40,7 @@ describe('Wire Commands', () => {
         },
       };
 
-      const result = Schema.decodeUnknownEither(WireCommand)(commandWithComplexPayload);
+      const result = pipe(commandWithComplexPayload, Schema.decodeUnknownEither(WireCommand));
       expect(result._tag).toBe('Right');
     });
   });
@@ -55,7 +55,7 @@ describe('Wire Commands', () => {
         },
       };
 
-      const result = Schema.decodeUnknownEither(CommandResult)(successResult);
+      const result = pipe(successResult, Schema.decodeUnknownEither(CommandResult));
       expect(result._tag).toBe('Right');
     });
 
@@ -70,7 +70,7 @@ describe('Wire Commands', () => {
         },
       };
 
-      const result = Schema.decodeUnknownEither(CommandResult)(failureResult);
+      const result = pipe(failureResult, Schema.decodeUnknownEither(CommandResult));
       expect(result._tag).toBe('Right');
     });
 
@@ -85,16 +85,16 @@ describe('Wire Commands', () => {
         },
       };
 
-      const result = Schema.decodeUnknownEither(CommandResult)(failureResult);
+      const result = pipe(failureResult, Schema.decodeUnknownEither(CommandResult));
       expect(result._tag).toBe('Right');
     });
   });
 
   describe('Command Validation', () => {
     const UserPayload = Schema.Struct({
-      email: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
-      name: Schema.String.pipe(Schema.minLength(1)),
-      age: Schema.optional(Schema.Number.pipe(Schema.between(13, 120))),
+      email: pipe(Schema.String, Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)),
+      name: pipe(Schema.String, Schema.minLength(1)),
+      age: Schema.optional(pipe(Schema.Number, Schema.between(13, 120))),
     });
 
     test('should validate and transform valid payload', async () => {

--- a/packages/eventsourcing-store-inmemory/src/lib/inMemory.spec.ts
+++ b/packages/eventsourcing-store-inmemory/src/lib/inMemory.spec.ts
@@ -19,14 +19,13 @@ export const FooEventStoreTest = (store: InMemoryStore<FooEvent>) =>
     pipe(store, makeInMemoryEventStore, Effect.map(encodedEventStore(FooEvent)))
   );
 
+const makeFooEventStoreLayer = () =>
+  pipe(make<FooEvent>(), Effect.map(FooEventStoreTest), Effect.runSync);
+
 // Run the shared test suite for the in-memory implementation
 // Note: In-memory store doesn't support horizontal scaling since each instance has its own memory
 runEventStoreTestSuite(
   'In-memory',
-  () =>
-    pipe(
-      pipe(make<FooEvent>(), Effect.map(FooEventStoreTest), Effect.runSync),
-      Layer.provide(LoggerLive)
-    ),
+  () => pipe(makeFooEventStoreLayer(), Layer.provide(LoggerLive)),
   { supportsHorizontalScaling: false }
 );

--- a/packages/eventsourcing-store/src/lib/errors.test.ts
+++ b/packages/eventsourcing-store/src/lib/errors.test.ts
@@ -157,20 +157,43 @@ describe('Event Sourcing Errors', () => {
   });
 
   describe('Constructor field assignment', () => {
-    it.each(['read', 'write', 'subscribe'] as const)(
-      'should create error with %s operation',
-      (operation) => {
-        const error = new EventStoreError({
-          operation,
-          streamId: 'test-stream',
-          details: 'test details',
-        });
+    it('should create error with read operation', () => {
+      const error = new EventStoreError({
+        operation: 'read',
+        streamId: 'test-stream',
+        details: 'test details',
+      });
 
-        expect(error._tag).toBe('EventStoreError');
-        expect(error.operation).toBe(operation);
-        expect(error.streamId).toBe('test-stream');
-        expect(error.details).toBe('test details');
-      }
-    );
+      expect(error._tag).toBe('EventStoreError');
+      expect(error.operation).toBe('read');
+      expect(error.streamId).toBe('test-stream');
+      expect(error.details).toBe('test details');
+    });
+
+    it('should create error with write operation', () => {
+      const error = new EventStoreError({
+        operation: 'write',
+        streamId: 'test-stream',
+        details: 'test details',
+      });
+
+      expect(error._tag).toBe('EventStoreError');
+      expect(error.operation).toBe('write');
+      expect(error.streamId).toBe('test-stream');
+      expect(error.details).toBe('test details');
+    });
+
+    it('should create error with subscribe operation', () => {
+      const error = new EventStoreError({
+        operation: 'subscribe',
+        streamId: 'test-stream',
+        details: 'test details',
+      });
+
+      expect(error._tag).toBe('EventStoreError');
+      expect(error.operation).toBe('subscribe');
+      expect(error.streamId).toBe('test-stream');
+      expect(error.details).toBe('test details');
+    });
   });
 });

--- a/packages/eventsourcing-store/src/lib/services.test.ts
+++ b/packages/eventsourcing-store/src/lib/services.test.ts
@@ -55,61 +55,74 @@ describe('Service Definitions', () => {
       expect(typeof EventStoreService).toBe('object');
     });
 
-    it.layer(
-      Layer.succeed(EventStoreService, {
-        append: () => {
-          throw new Error('Not implemented');
-        },
-        read: (from: EventStreamPosition) =>
-          Effect.fail(eventStoreError.read(from.streamId, 'Not implemented')),
-        subscribe: (from: EventStreamPosition) =>
-          Effect.fail(eventStoreError.read(from.streamId, 'Not implemented')),
-      } as EventStore<unknown>)
-    )('should work with dependency injection', (it) => {
-      it.effect('can handle dependency injection and error catching', () =>
-        pipe(
-          EventStoreService,
-          Effect.flatMap((store) =>
-            store.read({
-              streamId: 'test' as EventStreamId,
-              eventNumber: 0,
-            } as EventStreamPosition)
-          ),
-          Effect.catchTag('EventStoreError', (error) =>
-            Effect.succeed(`Caught error: ${error.message}`)
-          ),
-          Effect.map((result) => {
-            expect(result).toContain('Caught error:');
-          })
-        )
+    const testEventStoreErrorCatching = () =>
+      pipe(
+        EventStoreService,
+        Effect.flatMap((store) =>
+          store.read({
+            streamId: 'test' as EventStreamId,
+            eventNumber: 0,
+          } as EventStreamPosition)
+        ),
+        Effect.catchTag('EventStoreError', (error) =>
+          Effect.succeed(`Caught error: ${error.message}`)
+        ),
+        Effect.map((result) => {
+          expect(result).toContain('Caught error:');
+        })
       );
-    });
 
-    it.layer(
-      Layer.succeed(MyEventStoreService, {
-        append: () => {
-          throw new Error('Not implemented');
-        },
-        read: () => Effect.succeed(Stream.empty as Stream.Stream<MyEvent, never>),
-        subscribe: () => Effect.succeed(Stream.empty as Stream.Stream<MyEvent, never>),
-      } as EventStore<MyEvent>)
-    )('should support typed event stores', (it) => {
-      it.effect('can work with typed events', () =>
-        pipe(
-          MyEventStoreService,
-          Effect.flatMap((store) =>
-            store.read({
-              streamId: 'test' as EventStreamId,
-              eventNumber: 0,
-            } as EventStreamPosition)
-          ),
-          Effect.map(() => 'Success'),
-          Effect.map((result) => {
-            expect(result).toBe('Success');
-          })
-        )
+    pipe(
+      it.layer(
+        Layer.succeed(EventStoreService, {
+          append: () => {
+            throw new Error('Not implemented');
+          },
+          read: (from: EventStreamPosition) =>
+            Effect.fail(eventStoreError.read(from.streamId, 'Not implemented')),
+          subscribe: (from: EventStreamPosition) =>
+            Effect.fail(eventStoreError.read(from.streamId, 'Not implemented')),
+        } as EventStore<unknown>)
+      ),
+      (layeredIt) =>
+        layeredIt('should work with dependency injection', (it) => {
+          it.effect(
+            'can handle dependency injection and error catching',
+            testEventStoreErrorCatching
+          );
+        })
+    );
+
+    const testTypedEventStore = () =>
+      pipe(
+        MyEventStoreService,
+        Effect.flatMap((store) =>
+          store.read({
+            streamId: 'test' as EventStreamId,
+            eventNumber: 0,
+          } as EventStreamPosition)
+        ),
+        Effect.map(() => 'Success'),
+        Effect.map((result) => {
+          expect(result).toBe('Success');
+        })
       );
-    });
+
+    pipe(
+      it.layer(
+        Layer.succeed(MyEventStoreService, {
+          append: () => {
+            throw new Error('Not implemented');
+          },
+          read: () => Effect.succeed(Stream.empty as Stream.Stream<MyEvent, never>),
+          subscribe: () => Effect.succeed(Stream.empty as Stream.Stream<MyEvent, never>),
+        } as EventStore<MyEvent>)
+      ),
+      (layeredIt) =>
+        layeredIt('should support typed event stores', (it) => {
+          it.effect('can work with typed events', testTypedEventStore);
+        })
+    );
   });
 
   describe('ProjectionStoreService', () => {
@@ -118,33 +131,38 @@ describe('Service Definitions', () => {
       expect(typeof ProjectionStoreService).toBe('object');
     });
 
-    it.layer(
-      Layer.succeed(UserProjectionStoreService, {
-        get: (id: string) =>
-          id === 'user-1'
-            ? Effect.succeed({
-                id: 'user-1',
-                name: 'John',
-                email: 'john@example.com',
-              })
-            : Effect.succeed(null),
-        save: () => Effect.succeed(undefined),
-        delete: () => Effect.succeed(undefined),
-        list: () => Effect.succeed(['user-1', 'user-2']),
-        clear: () => Effect.succeed(undefined),
-      } as ProjectionStore<UserProjection>)
-    )('should work with dependency injection', (it) => {
-      it.effect('can get user projections', () =>
-        pipe(
-          UserProjectionStoreService,
-          Effect.flatMap((store) => store.get('user-1')),
-          Effect.map((user) => user?.name ?? 'Not found'),
-          Effect.map((result) => {
-            expect(result).toBe('John');
-          })
-        )
+    const testUserProjectionGet = () =>
+      pipe(
+        UserProjectionStoreService,
+        Effect.flatMap((store) => store.get('user-1')),
+        Effect.map((user) => user?.name ?? 'Not found'),
+        Effect.map((result) => {
+          expect(result).toBe('John');
+        })
       );
-    });
+
+    pipe(
+      it.layer(
+        Layer.succeed(UserProjectionStoreService, {
+          get: (id: string) =>
+            id === 'user-1'
+              ? Effect.succeed({
+                  id: 'user-1',
+                  name: 'John',
+                  email: 'john@example.com',
+                })
+              : Effect.succeed(null),
+          save: () => Effect.succeed(undefined),
+          delete: () => Effect.succeed(undefined),
+          list: () => Effect.succeed(['user-1', 'user-2']),
+          clear: () => Effect.succeed(undefined),
+        } as ProjectionStore<UserProjection>)
+      ),
+      (layeredIt) =>
+        layeredIt('should work with dependency injection', (it) => {
+          it.effect('can get user projections', testUserProjectionGet);
+        })
+    );
   });
 
   describe('SnapshotStoreService', () => {
@@ -153,73 +171,82 @@ describe('Service Definitions', () => {
       expect(typeof SnapshotStoreService).toBe('object');
     });
 
-    it.layer(
-      Layer.succeed(AggregateSnapshotStoreService, {
-        save: () => Effect.succeed(undefined),
-        load: (aggregateId: string, version?: number) =>
-          aggregateId === 'agg-1'
-            ? Effect.succeed({
-                version: version ?? 10,
-                snapshot: { version: 10, state: { active: true } },
-              })
-            : Effect.succeed(null),
-        delete: () => Effect.succeed(undefined),
-        list: () => Effect.succeed([1, 5, 10]),
-      } as SnapshotStore<AggregateSnapshot>)
-    )('should work with dependency injection', (it) => {
-      it.effect('can load aggregate snapshots', () =>
-        pipe(
-          AggregateSnapshotStoreService,
-          Effect.flatMap((store) => store.load('agg-1')),
-          Effect.map((result) => result?.snapshot.version ?? 0),
-          Effect.map((result) => {
-            expect(result).toBe(10);
-          })
-        )
+    const testSnapshotLoad = () =>
+      pipe(
+        AggregateSnapshotStoreService,
+        Effect.flatMap((store) => store.load('agg-1')),
+        Effect.map((result) => result?.snapshot.version ?? 0),
+        Effect.map((result) => {
+          expect(result).toBe(10);
+        })
       );
-    });
+
+    pipe(
+      it.layer(
+        Layer.succeed(AggregateSnapshotStoreService, {
+          save: () => Effect.succeed(undefined),
+          load: (aggregateId: string, version?: number) =>
+            aggregateId === 'agg-1'
+              ? Effect.succeed({
+                  version: version ?? 10,
+                  snapshot: { version: 10, state: { active: true } },
+                })
+              : Effect.succeed(null),
+          delete: () => Effect.succeed(undefined),
+          list: () => Effect.succeed([1, 5, 10]),
+        } as SnapshotStore<AggregateSnapshot>)
+      ),
+      (layeredIt) =>
+        layeredIt('should work with dependency injection', (it) => {
+          it.effect('can load aggregate snapshots', testSnapshotLoad);
+        })
+    );
   });
 
   describe('Service composition', () => {
-    it.layer(
-      Layer.mergeAll(
-        Layer.succeed(EventStoreService, {
-          append: () => {
-            throw new Error('Not implemented');
-          },
-          read: () => Effect.fail(eventStoreError.read(undefined, 'Not implemented')),
-          subscribe: () => Effect.fail(eventStoreError.read(undefined, 'Not implemented')),
-        } as EventStore<unknown>),
-        Layer.succeed(ProjectionStoreService, {
-          get: () => Effect.succeed(null),
-          save: () => Effect.succeed(undefined),
-          delete: () => Effect.succeed(undefined),
-          list: () => Effect.succeed([]),
-          clear: () => Effect.succeed(undefined),
-        } as ProjectionStore<unknown>),
-        Layer.succeed(SnapshotStoreService, {
-          save: () => Effect.succeed(undefined),
-          load: () => Effect.succeed(null),
-          delete: () => Effect.succeed(undefined),
-          list: () => Effect.succeed([]),
-        } as SnapshotStore<unknown>)
-      )
-    )('should allow combining multiple services', (it) => {
-      it.effect('can access all services simultaneously', () =>
-        pipe(
-          Effect.all([EventStoreService, ProjectionStoreService, SnapshotStoreService]),
-          Effect.map(([eventStore, projectionStore, snapshotStore]) => {
-            // All services should be available
-            expect(eventStore).toBeDefined();
-            expect(projectionStore).toBeDefined();
-            expect(snapshotStore).toBeDefined();
-            return 'All services available';
-          }),
-          Effect.map((result) => {
-            expect(result).toBe('All services available');
-          })
-        )
+    const testAllServicesAvailable = () =>
+      pipe(
+        Effect.all([EventStoreService, ProjectionStoreService, SnapshotStoreService]),
+        Effect.map(([eventStore, projectionStore, snapshotStore]) => {
+          expect(eventStore).toBeDefined();
+          expect(projectionStore).toBeDefined();
+          expect(snapshotStore).toBeDefined();
+          return 'All services available';
+        }),
+        Effect.map((result) => {
+          expect(result).toBe('All services available');
+        })
       );
-    });
+
+    pipe(
+      it.layer(
+        Layer.mergeAll(
+          Layer.succeed(EventStoreService, {
+            append: () => {
+              throw new Error('Not implemented');
+            },
+            read: () => Effect.fail(eventStoreError.read(undefined, 'Not implemented')),
+            subscribe: () => Effect.fail(eventStoreError.read(undefined, 'Not implemented')),
+          } as EventStore<unknown>),
+          Layer.succeed(ProjectionStoreService, {
+            get: () => Effect.succeed(null),
+            save: () => Effect.succeed(undefined),
+            delete: () => Effect.succeed(undefined),
+            list: () => Effect.succeed([]),
+            clear: () => Effect.succeed(undefined),
+          } as ProjectionStore<unknown>),
+          Layer.succeed(SnapshotStoreService, {
+            save: () => Effect.succeed(undefined),
+            load: () => Effect.succeed(null),
+            delete: () => Effect.succeed(undefined),
+            list: () => Effect.succeed([]),
+          } as SnapshotStore<unknown>)
+        )
+      ),
+      (layeredIt) =>
+        layeredIt('should allow combining multiple services', (it) => {
+          it.effect('can access all services simultaneously', testAllServicesAvailable);
+        })
+    );
   });
 });

--- a/packages/eventsourcing-store/src/lib/streaming/connectionManager.test.ts
+++ b/packages/eventsourcing-store/src/lib/streaming/connectionManager.test.ts
@@ -9,24 +9,26 @@ import {
   makeConnectionManager,
 } from './connectionManager';
 
+const verifyApiPort = (manager: ReadonlyDeep<ConnectionManagerService>) =>
+  pipe(
+    manager.getApiPort(),
+    Effect.provide(LoggerLive),
+    Effect.tap((apiPort) => Effect.sync(() => expect(typeof apiPort).toBe('number')))
+  );
+
+const verifyManagerAndApiPort = (manager: ReadonlyDeep<ConnectionManagerService>) =>
+  pipe(
+    Effect.sync(() => expect(manager).toBeDefined()),
+    Effect.flatMap(() => verifyApiPort(manager))
+  );
+
 describe('ConnectionManager', () => {
   // Single minimal test to ensure the module loads
   it.effect('should create a connection manager', () =>
     pipe(
       makeConnectionManager(DefaultConnectionConfig),
       Effect.provide(LoggerLive),
-      Effect.flatMap((manager: ReadonlyDeep<ConnectionManagerService>) =>
-        pipe(
-          Effect.sync(() => expect(manager).toBeDefined()),
-          Effect.flatMap(() =>
-            pipe(
-              manager.getApiPort(),
-              Effect.provide(LoggerLive),
-              Effect.tap((apiPort) => Effect.sync(() => expect(typeof apiPort).toBe('number')))
-            )
-          )
-        )
-      )
+      Effect.flatMap(verifyManagerAndApiPort)
     )
   );
 });


### PR DESCRIPTION
## Summary
- Extract shared ESLint rules into named constants to eliminate duplication
- Enforce simple pipe rules on test files (excluding buntest package)
- Improve configuration maintainability and consistency

## Changes
- Created reusable constants for plugin configs, language options, and rule sets
- Simplified config objects from 67 lines down to 5 lines in some cases
- Added simple pipe syntax restrictions to test files
- All lint checks passing across 13 packages

## Impact
- No functional changes to linting behavior for production code
- Test files now enforce the same pipe patterns as production code
- Easier to maintain and update linting rules going forward