### PR TITLE
refactor(lint): add ESLint rule to detect identity functions

### DIFF
--- a/.changeset/detect-identity-functions.md
+++ b/.changeset/detect-identity-functions.md
@@ -1,0 +1,4 @@
+---
+---
+
+ESLint now detects and prevents pointless identity functions in Effect transformations (e.g., `Effect.map((x) => x)`). These no-op transformations add unnecessary noise to code pipelines and are now flagged as errors, helping maintain cleaner and more intentional Effect compositions.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -119,6 +119,12 @@ const simplePipeSyntaxRestrictions = [
     message:
       'Multiple pipe() calls in a function are forbidden. Extract additional pipes to separate named functions.',
   },
+  {
+    selector:
+      'CallExpression[callee.property.name=/^(map|flatMap|filterMap|tap|forEach)$/] > ArrowFunctionExpression[params.length=1][params.0.type="Identifier"][body.type="Identifier"]',
+    message:
+      'Identity function in transformation is pointless. Example: Effect.map((x) => x) does nothing. Remove it or replace with the actual transformation needed.',
+  },
 ];
 
 // Common functional immutability rules

--- a/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
+++ b/packages/eventsourcing-aggregates/src/lib/command-processing.test.ts
@@ -285,11 +285,7 @@ describe('Command Processing Service', () => {
       readonly processCommand: (
         command: Readonly<WireCommand>
       ) => Effect.Effect<CommandResult, CommandProcessingError, never>;
-    }) =>
-      pipe(
-        Effect.all(testCommands.map((cmd) => service.processCommand(cmd))),
-        Effect.map((results) => results)
-      );
+    }) => Effect.all(testCommands.map((cmd) => service.processCommand(cmd)));
 
     return pipe(
       createCommandProcessingService(TestEventStore)(router),

--- a/packages/eventsourcing-transport-websocket/src/lib/websocket-transport.ts
+++ b/packages/eventsourcing-transport-websocket/src/lib/websocket-transport.ts
@@ -402,8 +402,7 @@ const connectWebSocket = (
     Effect.tap(({ stateRef }) => updateConnectionState(stateRef, 'connecting')),
     Effect.flatMap(({ stateRef, writerRef, connectedDeferred }) =>
       acquireWebSocketConnection(url, stateRef, writerRef, connectedDeferred)
-    ),
-    Effect.map((transport): Client.Transport => transport)
+    )
   );
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds new ESLint rule to detect pointless identity functions in Effect transformations
- Catches patterns like `Effect.map((x) => x)` which add no value
- Avoids false positives from legitimate tuple destructuring operations
- Removes two violations found in the codebase

## Test plan

- [x] All linting passes with new rule
- [x] Existing violations fixed
- [x] No false positives on legitimate patterns
- [x] All tests pass