### PR TITLE
refactor(lint): require justification for all ESLint disable comments

### DIFF
--- a/.changeset/require-eslint-disable-justifications.md
+++ b/.changeset/require-eslint-disable-justifications.md
@@ -1,0 +1,11 @@
+---
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+---
+
+Enforce documented justifications for all ESLint rule suppressions
+
+All `eslint-disable` comments now require a description explaining why the rule is being suppressed. This improves code maintainability by documenting the reasoning behind each exception to the linting rules.

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "eslint": "9.36.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-compat": "6.0.2",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-expect-type": "0.6.2",
         "eslint-plugin-functional": "9.0.2",
         "eslint-plugin-import": "2.32.0",
@@ -45,7 +46,6 @@
       "version": "0.0.1",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.44.1",
-        "@typescript-eslint/parser": "8.44.1",
         "effect": "3.17.14",
         "eslint": "9.36.0",
         "typescript": "5.9.2",
@@ -767,6 +767,8 @@
 
     "eslint-plugin-compat": ["eslint-plugin-compat@6.0.2", "", { "dependencies": { "@mdn/browser-compat-data": "^5.5.35", "ast-metadata-inferer": "^0.8.1", "browserslist": "^4.24.2", "caniuse-lite": "^1.0.30001687", "find-up": "^5.0.0", "globals": "^15.7.0", "lodash.memoize": "^4.1.2", "semver": "^7.6.2" }, "peerDependencies": { "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0" } }, "sha512-1ME+YfJjmOz1blH0nPZpHgjMGK4kjgEeoYqGCqoBPQ/mGu/dJzdoP0f1C8H2jcWZjzhZjAMccbM/VdXhPORIfA=="],
 
+    "eslint-plugin-eslint-comments": ["eslint-plugin-eslint-comments@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5", "ignore": "^5.0.5" }, "peerDependencies": { "eslint": ">=4.19.1" } }, "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ=="],
+
     "eslint-plugin-expect-type": ["eslint-plugin-expect-type@0.6.2", "", { "dependencies": { "@typescript-eslint/utils": "^6.10.0 || ^7.0.1 || ^8", "fs-extra": "^11.1.1", "get-tsconfig": "^4.8.1" }, "peerDependencies": { "@typescript-eslint/parser": ">=6", "eslint": ">=7", "typescript": ">=4" } }, "sha512-XWgtpplzr6GlpPUFG9ZApnSTv7QJXAPNN6hNmrlleVVCkAK23f/3E2BiCoA3Xtb0rIKfVKh7TLe+D1tcGt8/1w=="],
 
     "eslint-plugin-functional": ["eslint-plugin-functional@9.0.2", "", { "dependencies": { "@typescript-eslint/utils": "^8.26.0", "deepmerge-ts": "^7.1.5", "escape-string-regexp": "^5.0.0", "is-immutable-type": "^5.0.1", "ts-api-utils": "^2.0.1", "ts-declaration-location": "^1.0.6" }, "peerDependencies": { "eslint": "^9.0.0", "typescript": ">=4.7.4" }, "optionalPeers": ["typescript"] }, "sha512-N8kP9HX1CJ2HrufPHLzsKNJ81O1IB25jw2mxOc1H1z3CamEu8MYTn9dOo/FPfQwsqHZVuf7wyDCBcL8r8H7N0w=="],
@@ -1430,6 +1432,10 @@
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "eslint-plugin-eslint-comments/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "eslint-plugin-eslint-comments/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-plugin-expect-type/@typescript-eslint/utils": ["@typescript-eslint/utils@8.44.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.44.0", "@typescript-eslint/types": "8.44.0", "@typescript-eslint/typescript-estree": "8.44.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import unusedImports from 'eslint-plugin-unused-imports';
 import importPlugin from 'eslint-plugin-import';
 import prettier from 'eslint-config-prettier';
 import functionalPlugin from 'eslint-plugin-functional';
+import eslintComments from 'eslint-plugin-eslint-comments';
 
 // Shared configuration pieces
 const commonLanguageOptions = {
@@ -26,6 +27,7 @@ const commonPlugins = {
   '@typescript-eslint': typescript,
   'unused-imports': unusedImports,
   import: importPlugin,
+  'eslint-comments': eslintComments,
 };
 
 const commonPluginsWithFunctional = {
@@ -249,6 +251,7 @@ const typescriptBaseRules = {
       tsx: 'never',
     },
   ],
+  'eslint-comments/require-description': ['error', { ignore: [] }],
 };
 
 // Test file imports restrictions

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint": "9.36.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-compat": "6.0.2",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-expect-type": "0.6.2",
     "eslint-plugin-functional": "9.0.2",
     "eslint-plugin-import": "2.32.0",

--- a/packages/eventsourcing-commands/src/lib/command-registry.ts
+++ b/packages/eventsourcing-commands/src/lib/command-registry.ts
@@ -36,7 +36,7 @@ export const dispatchCommand = (
  * Helper to create a command matcher using Effect's pattern matching
  * Since our commands use 'name' instead of '_tag', this provides a convenient API
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept all command payload types
 export const createCommandMatcher = <TCommands extends DomainCommand<any>>() =>
   Match.type<TCommands>();
 
@@ -45,7 +45,7 @@ export const createCommandMatcher = <TCommands extends DomainCommand<any>>() =>
  * This ensures exhaustive command handling with compile-time safety
  */
 export const makeCommandRegistry = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept command definitions with any payload type
   const T extends readonly CommandDefinition<string, any>[],
 >(
   commands: ReadonlyDeep<T>,
@@ -118,7 +118,7 @@ export const makeCommandRegistry = <
  * Creates a Layer with the command registry
  */
 export const makeCommandRegistryLayer = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept command definitions with any payload type
   const T extends readonly CommandDefinition<string, any>[],
 >(
   commands: ReadonlyDeep<T>,

--- a/packages/eventsourcing-commands/src/lib/commands.ts
+++ b/packages/eventsourcing-commands/src/lib/commands.ts
@@ -139,7 +139,7 @@ export const isCommandFailure = Schema.is(CommandFailure);
  */
 export interface CommandDefinition<TName extends string, TPayload> {
   readonly name: TName;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Schema input type can be any, TypeScript will infer the correct type from schema definition
   readonly payloadSchema: Schema.Schema<TPayload, any>;
 }
 
@@ -157,7 +157,7 @@ export const defineCommand = <TName extends string, TPayload, TPayloadInput>(
 /**
  * Helper type to extract command union from command definitions
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept command definitions with any payload type
 export type CommandFromDefinitions<T extends readonly CommandDefinition<string, any>[]> = {
   readonly [K in keyof T]: T[K] extends CommandDefinition<infer Name, infer Payload>
     ? {
@@ -174,7 +174,7 @@ export type CommandFromDefinitions<T extends readonly CommandDefinition<string, 
  * This creates an exhaustive schema that can parse any registered command
  */
 export const buildCommandSchema = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept command definitions with any payload type
   const T extends readonly CommandDefinition<string, any>[],
 >(
   commands: ReadonlyDeep<T>
@@ -196,7 +196,7 @@ export const buildCommandSchema = <
   );
 
   if (schemas.length === 1) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type assertion required to match return type when single schema array
     return schemas[0]! as any;
   }
 
@@ -205,7 +205,7 @@ export const buildCommandSchema = <
   if (!first || !second) {
     throw new Error('Unexpected state: should have at least 2 schemas');
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type assertion required to match return type for union of variable schemas
   return Schema.Union(first, second, ...rest) as any;
 };
 
@@ -244,7 +244,7 @@ export const validateCommand =
  * Command matcher function type
  * Uses Effect's pattern matching for exhaustive command handling
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic constraint requires any to accept all command payload types
 export type CommandMatcher<TCommands extends DomainCommand<any>> = (
   command: ReadonlyDeep<TCommands>
 ) => Effect.Effect<CommandResult, never, never>;

--- a/packages/eventsourcing-protocol/src/lib/protocol.test.ts
+++ b/packages/eventsourcing-protocol/src/lib/protocol.test.ts
@@ -258,7 +258,7 @@ const verifyFailureResult =
               readonly _tag: string;
               readonly validationErrors?: readonly string[];
             };
-            // eslint-disable-next-line no-restricted-syntax
+            // eslint-disable-next-line no-restricted-syntax -- Test needs to verify _tag in serialized error JSON
             expect(parsedError._tag).toBe(expectedErrorTag);
             if (expectedErrors) {
               expect(parsedError.validationErrors).toEqual(expectedErrors);

--- a/packages/eventsourcing-store-postgres/src/sqlEventStore.ts
+++ b/packages/eventsourcing-store-postgres/src/sqlEventStore.ts
@@ -24,7 +24,7 @@ import {
 
 // Define the EventRowService interface
 interface EventRowServiceInterface {
-  // eslint-disable-next-line functional/prefer-immutable-types
+  // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
   readonly insert: (row: EventRow) => Effect.Effect<EventRow, unknown, never>;
   readonly selectAllEventsInStream: (
     streamId: EventStreamId
@@ -184,9 +184,9 @@ const getHistoricalEventsAndConcatWithLive = (
     eventRows.selectAllEventsInStream,
     Effect.map((events: readonly EventRow[]) => {
       const filteredEvents = events
-        // eslint-disable-next-line functional/prefer-immutable-types
+        // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
         .filter((event: EventRow) => event.event_number >= from.eventNumber)
-        // eslint-disable-next-line functional/prefer-immutable-types
+        // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
         .map((event: EventRow) => event.event_payload);
       return Stream.fromIterable(filteredEvents);
     }),
@@ -282,9 +282,9 @@ const readHistoricalEvents = (eventRows: EventRowServiceInterface, from: EventSt
     eventRows.selectAllEventsInStream,
     Effect.map((events: readonly EventRow[]) => {
       const filteredEvents = events
-        // eslint-disable-next-line functional/prefer-immutable-types
+        // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
         .filter((event: EventRow) => event.event_number >= from.eventNumber)
-        // eslint-disable-next-line functional/prefer-immutable-types
+        // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
         .map((event: EventRow) => event.event_payload);
       return Stream.fromIterable(filteredEvents);
     }),
@@ -379,7 +379,7 @@ const appendEventToStream = (
         event_payload: payload,
       })
     ),
-    // eslint-disable-next-line functional/prefer-immutable-types
+    // eslint-disable-next-line functional/prefer-immutable-types -- EventRow type comes from Postgres library and cannot be made immutable
     Effect.map((row: EventRow) => ({
       streamId: row.stream_id,
       eventNumber: row.event_number + 1,

--- a/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
+++ b/packages/eventsourcing-store/src/lib/testing/eventstore-test-suite.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports, no-restricted-syntax */
+/* eslint-disable no-restricted-imports, no-restricted-syntax -- Test suite contract that must work with bun:test directly and may use restricted patterns for comprehensive EventStore testing */
 import { Chunk, Effect, Layer, ParseResult, Schema, Stream, pipe, Ref } from 'effect';
 import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { EventStreamId, EventStreamPosition, beginning } from '../streamTypes';

--- a/packages/eventsourcing-transport-websocket/src/lib/websocket-server.ts
+++ b/packages/eventsourcing-transport-websocket/src/lib/websocket-server.ts
@@ -274,7 +274,7 @@ const registerClientAndTransition =
       updateClientConnectionState(clientState, 'connecting'),
       Effect.flatMap(() => addClientToServerState(serverStateRef, clientState)),
       Effect.flatMap(() => {
-        // eslint-disable-next-line functional/immutable-data
+        // eslint-disable-next-line functional/immutable-data -- Bun WebSocket API requires mutating the data property to attach client metadata
         (ws as ServerWebSocket<{ readonly clientId: Server.ClientId }>).data = {
           clientId: clientState.id,
         };
@@ -351,7 +351,7 @@ const createWebSocketServer = (
                 connectedAt: new Date(),
               }));
 
-            // eslint-disable-next-line no-restricted-syntax
+            // eslint-disable-next-line no-restricted-syntax -- WebSocket open handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 createClientIdAndTimestamp(),
@@ -367,7 +367,7 @@ const createWebSocketServer = (
             ws: ReadonlyDeep<ServerWebSocket<{ readonly clientId: Server.ClientId }>>,
             message: ReadonlyDeep<string>
           ) => {
-            // eslint-disable-next-line no-restricted-syntax
+            // eslint-disable-next-line no-restricted-syntax -- WebSocket message handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 serverStateRef,
@@ -381,7 +381,7 @@ const createWebSocketServer = (
           },
 
           close: (ws: ReadonlyDeep<ServerWebSocket<{ readonly clientId: Server.ClientId }>>) => {
-            // eslint-disable-next-line no-restricted-syntax
+            // eslint-disable-next-line no-restricted-syntax -- WebSocket close handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 serverStateRef,


### PR DESCRIPTION
## Summary

Enforces documented justifications for all ESLint rule suppressions by adding the `eslint-comments/require-description` rule.

## Changes

- Install `eslint-plugin-eslint-comments` 
- Enable `eslint-comments/require-description` rule in ESLint config
- Add justifications to all existing `eslint-disable` comments explaining why each suppression is necessary

## Benefits

- Improves code maintainability by documenting the reasoning behind each linting exception
- Makes it easier for developers to understand why rules were disabled in specific cases
- Prevents arbitrary rule suppressions without clear justification

## Test Plan

- [x] All existing tests pass
- [x] `turbo all` completes successfully
- [x] All `eslint-disable` comments now include justifications