### PR TITLE
docs(client): improve client documentation for transport abstraction

### DIFF
--- a/.changeset/improve-client-docs.md
+++ b/.changeset/improve-client-docs.md
@@ -1,0 +1,19 @@
+---
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+---
+
+Improved client documentation to emphasize transport abstraction.
+
+The documentation now clearly shows:
+
+- Protocol package provides transport-agnostic API (`sendWireCommand`, `subscribe`)
+- WebSocket package is used only for creating Effect layers
+- Application code should be written against protocol abstractions
+- Transport choice (WebSocket, HTTP, etc.) is configured once when setting up layers
+
+This makes it easier to:
+
+- Write transport-independent application code
+- Switch transports without changing application logic
+- Understand the proper separation between layers

--- a/packages/eventsourcing-websocket/README.md
+++ b/packages/eventsourcing-websocket/README.md
@@ -1,70 +1,154 @@
 # @codeforbreakfast/eventsourcing-websocket
 
-**WebSocket integration package** - Combines WebSocket transport with event sourcing protocols for rapid development.
+**WebSocket transport layer setup** for event sourcing clients.
 
-## Features
+## Purpose
 
-- ✅ **WebSocket Transport** - Full client and server WebSocket implementation
-- ✅ **Protocol Layer** - Command/event protocol with optimistic concurrency
-- ✅ **Convenience API** - One-line setup for event sourcing over WebSocket
+This package provides the WebSocket transport implementation for connecting to event sourcing servers. **Use this package ONLY for creating your Effect Layer** - all application logic should use `@codeforbreakfast/eventsourcing-protocol`.
+
+**Key principle**: Your application code shouldn't know it's using WebSocket. This is a deployment detail configured once when setting up layers.
 
 ## Installation
 
 ```bash
 bun add @codeforbreakfast/eventsourcing-websocket
+bun add @codeforbreakfast/eventsourcing-protocol
+bun add @codeforbreakfast/eventsourcing-commands
 ```
 
-## Quick Start
+## Layer Setup
+
+### Recommended: Layer-based Setup
+
+```typescript
+import { makeWebSocketProtocolLayer } from '@codeforbreakfast/eventsourcing-websocket';
+import { sendWireCommand, subscribe } from '@codeforbreakfast/eventsourcing-protocol';
+import type { WireCommand } from '@codeforbreakfast/eventsourcing-commands';
+import { Effect, Stream } from 'effect';
+
+// ============================================================================
+// Application Code (transport-agnostic)
+// ============================================================================
+
+const myApplication = Effect.gen(function* () {
+  // Your code uses protocol abstractions - doesn't know about WebSocket
+  const command: WireCommand = {
+    id: crypto.randomUUID(),
+    target: 'user-123',
+    name: 'CreateUser',
+    payload: { name: 'Alice', email: 'alice@example.com' },
+  };
+
+  const result = yield* sendWireCommand(command);
+
+  const events = yield* subscribe('user-123');
+  yield* Stream.runForEach(events, (event) => Effect.sync(() => console.log('Event:', event.type)));
+});
+
+// ============================================================================
+// Layer Setup (WebSocket-specific - ONE PLACE ONLY)
+// ============================================================================
+
+const layer = makeWebSocketProtocolLayer('ws://localhost:8080');
+
+// Run application with WebSocket transport
+await Effect.runPromise(myApplication.pipe(Effect.provide(layer)));
+```
+
+To switch transports (e.g., to HTTP), you'd only change the layer - application code stays the same.
+
+### Convenience: Direct Connection
+
+For quick prototypes or scripts:
 
 ```typescript
 import { connect } from '@codeforbreakfast/eventsourcing-websocket';
-import { Effect, pipe } from 'effect';
+import { Effect } from 'effect';
 
 const program = Effect.scoped(
   Effect.gen(function* () {
-    // Connect with batteries-included protocol
+    // Returns Protocol service directly
     const protocol = yield* connect('ws://localhost:8080');
 
-    // Send commands and receive events seamlessly
-    const result = yield* protocol.sendCommand({
-      id: 'cmd-1',
-      target: 'user:123',
-      type: 'user.register',
-      payload: { email: 'user@example.com' },
+    const result = yield* protocol.sendWireCommand({
+      id: crypto.randomUUID(),
+      target: 'user-123',
+      name: 'CreateUser',
+      payload: { name: 'Alice' },
     });
+  })
+);
 
-    // Subscribe to events
-    const events = yield* protocol.subscribeToEvents('user:123');
+await Effect.runPromise(program);
+```
+
+**Note**: The layer-based approach is preferred for production applications as it supports dependency injection and testing.
+
+## API Reference
+
+### `makeWebSocketProtocolLayer`
+
+```typescript
+const makeWebSocketProtocolLayer: (
+  url: string
+) => Layer<Protocol, TransportError | ConnectionError, Scope>;
+```
+
+Creates an Effect Layer that provides the Protocol service over WebSocket.
+
+**Parameters:**
+
+- `url: string` - WebSocket server URL (e.g., `ws://localhost:8080`)
+
+**Returns:** Layer that can be provided to your application
+
+**Example:**
+
+```typescript
+const layer = makeWebSocketProtocolLayer('ws://localhost:8080');
+Effect.runPromise(myApp.pipe(Effect.provide(layer)));
+```
+
+### `connect`
+
+```typescript
+const connect: (
+  url: string
+) => Effect<Protocol, TransportError | ConnectionError, Protocol | Scope>;
+```
+
+Convenience function that connects and returns the Protocol service directly.
+
+**Parameters:**
+
+- `url: string` - WebSocket server URL
+
+**Returns:** Effect providing Protocol service (must be run in scoped context)
+
+**Example:**
+
+```typescript
+const program = Effect.scoped(
+  Effect.gen(function* () {
+    const protocol = yield* connect('ws://localhost:8080');
+    // use protocol...
   })
 );
 ```
 
-## Advanced Usage
+## Next Steps
 
-### Custom Configuration
+Once you've set up your WebSocket layer, see the following packages for building your application:
 
-```typescript
-import { connect, makeWebSocketProtocolLayer } from '@codeforbreakfast/eventsourcing-websocket';
-import { Layer, Effect } from 'effect';
+- **[@codeforbreakfast/eventsourcing-protocol](../eventsourcing-protocol)** - Send commands and subscribe to events (your main application API)
+- **[@codeforbreakfast/eventsourcing-commands](../eventsourcing-commands)** - WireCommand and CommandResult types
+- **[@codeforbreakfast/eventsourcing-store](../eventsourcing-store)** - Event types and event store contracts
 
-// Create a custom layer for dependency injection
-const customLayer = makeWebSocketProtocolLayer('ws://localhost:8080');
+## Advanced: Low-Level Transport
 
-const program = Effect.gen(function* () {
-  const protocol = yield* Protocol;
-  // Use protocol...
-}).pipe(Effect.provide(customLayer));
-```
+If you need access to the raw WebSocket transport (for advanced use cases), see:
 
-### Server-side Usage
-
-For server implementations, use the transport package directly:
-
-```bash
-bun add @codeforbreakfast/eventsourcing-transport-websocket
-```
-
-See the [WebSocket Transport README](../eventsourcing-transport-websocket/README.md) for server setup.
+- **[@codeforbreakfast/eventsourcing-transport-websocket](../eventsourcing-transport-websocket)** - Low-level WebSocket transport implementation
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Improved client-facing documentation to emphasize transport-agnostic patterns and proper package separation.

## Changes

**Protocol README:**
- Shows transport-agnostic client API (`sendWireCommand`, `subscribe`)
- Shows server API (`ServerProtocol` service)
- Removes internal `Protocol*` types from examples
- Makes clear this is the main application API regardless of transport

**WebSocket README:**
- Focuses solely on Layer creation for setup
- Makes clear WebSocket is only mentioned when wiring up layers
- Points to Protocol package for all application logic
- Shows both Layer-based (recommended) and direct connection patterns

## Key Principle

Application code should work with Protocol abstractions (Layer 3). Transport choice (WebSocket, etc.) is a deployment detail configured once when setting up Effect layers.

This separation encourages clients to:

1. Write transport-agnostic application code using eventsourcing-protocol
2. Choose transport implementation only when creating layers
3. Easily swap transports without changing application code

## Testing

- All tests pass
- Documentation-only changes