### PR TITLE
feat(aggregates): make command initiator generic

### DIFF
--- a/.changeset/generic-command-initiator.md
+++ b/.changeset/generic-command-initiator.md
@@ -1,0 +1,5 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': minor
+---
+
+Make CommandContext and event metadata generic over initiator type. Command initiator is now supplied when creating aggregates and event schemas. The originator field optionality is configurable by the caller.

--- a/packages/eventsourcing-aggregates/src/lib/commandInitiator.ts
+++ b/packages/eventsourcing-aggregates/src/lib/commandInitiator.ts
@@ -1,21 +1,14 @@
-import { Context, Effect, Layer, Option, pipe, Schema } from 'effect';
-
-// Mock PersonId for now - replace with actual implementation
-const PersonId = pipe(Schema.String, Schema.brand('PersonId'));
-type PersonId = typeof PersonId.Type;
+import { Context, Effect, Layer, Option } from 'effect';
 import { CurrentUserError } from './currentUser';
 
-export const CommandInitiatorId = Schema.Union(PersonId);
-export type CommandInitiatorId = typeof CommandInitiatorId.Type;
+export interface CommandContextService<TInitiator> {
+  readonly getInitiator: Effect.Effect<Option.Option<TInitiator>, CurrentUserError>;
+}
 
-export class CommandContext extends Context.Tag('CommandContext')<
-  CommandContext,
-  {
-    readonly getInitiatorId: Effect.Effect<Option.Option<CommandInitiatorId>, CurrentUserError>;
-  }
->() {}
+export const CommandContext = <TInitiator>() =>
+  Context.GenericTag<CommandContextService<TInitiator>>('CommandContext');
 
-export const CommandContextTest = (initiatorId: Readonly<Option.Option<CommandInitiatorId>>) =>
-  Layer.succeed(CommandContext, {
-    getInitiatorId: Effect.succeed(initiatorId),
+export const CommandContextTest = <TInitiator>(initiator: Readonly<Option.Option<TInitiator>>) =>
+  Layer.succeed(CommandContext<TInitiator>(), {
+    getInitiator: Effect.succeed(initiator),
   });


### PR DESCRIPTION
## Summary

Makes CommandContext and event metadata generic over initiator type. Command initiator is now supplied when creating aggregates and event schemas. The originator field optionality is configurable by the caller.

## Changes

- `EventMetadata` is now a factory that takes an originator schema
- `eventSchema` takes the originator schema as the first parameter
- `CommandContext` is now a factory function: `CommandContext<TInitiator>()`
- `makeAggregateRoot` requires an initiator schema as the second parameter
- Caller decides if originator is required or optional (e.g., `PersonId` vs `Schema.OptionFromSelf(PersonId)`)