### PR TITLE
feat(eslint): enforce Match.tag for _tag discriminators

### DIFF
--- a/.changeset/prefer-match-tag-rule.md
+++ b/.changeset/prefer-match-tag-rule.md
@@ -1,0 +1,5 @@
+---
+'@codeforbreakfast/eventsourcing-protocol': patch
+---
+
+Improved type safety and code clarity by enforcing Match.tag() over Match.when() for discriminated union matching. The codebase now consistently uses Match.tag() when matching on \_tag discriminators, providing better type inference and clearer intent.

--- a/eslint-rules/prefer-match-tag.js
+++ b/eslint-rules/prefer-match-tag.js
@@ -1,0 +1,72 @@
+/**
+ * Custom ESLint rule to enforce Match.tag over Match.when for _tag matching
+ * Flags: Match.when({ _tag: 'Value' }, handler)
+ * Suggests: Match.tag('Value', handler)
+ */
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce using Match.tag() instead of Match.when() when matching on _tag discriminator. Match.tag provides better type safety and clearer intent.',
+    },
+    messages: {
+      preferMatchTag:
+        'Use Match.tag() instead of Match.when() for _tag matching. Match.when({ _tag: "{{tagValue}}" }, ...) should be Match.tag("{{tagValue}}", ...).',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Check for Match.when calls
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Match' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'when' &&
+          node.arguments.length >= 1
+        ) {
+          const firstArg = node.arguments[0];
+
+          // Check if first argument is an object literal with _tag property
+          if (firstArg.type === 'ObjectExpression' && firstArg.properties.length === 1) {
+            const prop = firstArg.properties[0];
+
+            if (
+              prop.type === 'Property' &&
+              prop.key.type === 'Identifier' &&
+              prop.key.name === '_tag' &&
+              prop.value.type === 'Literal' &&
+              typeof prop.value.value === 'string'
+            ) {
+              const tagValue = prop.value.value;
+
+              context.report({
+                node,
+                messageId: 'preferMatchTag',
+                data: {
+                  tagValue,
+                },
+                fix(fixer) {
+                  const sourceCode = context.getSourceCode();
+                  const tagString = sourceCode.getText(prop.value);
+                  const restArgs = node.arguments.slice(1);
+                  const restArgsText = restArgs.map((arg) => sourceCode.getText(arg)).join(', ');
+
+                  return fixer.replaceText(
+                    node,
+                    `Match.tag(${tagString}${restArgsText ? `, ${restArgsText}` : ''})`
+                  );
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import prettier from 'eslint-config-prettier';
 import functionalPlugin from 'eslint-plugin-functional';
 import eslintComments from 'eslint-plugin-eslint-comments';
 import noUnnecessaryPipeWrapper from './eslint-rules/no-unnecessary-pipe-wrapper.js';
+import preferMatchTag from './eslint-rules/prefer-match-tag.js';
 
 // Shared configuration pieces
 const commonLanguageOptions = {
@@ -32,6 +33,7 @@ const commonPlugins = {
   'custom-rules': {
     rules: {
       'no-unnecessary-pipe-wrapper': noUnnecessaryPipeWrapper,
+      'prefer-match-tag': preferMatchTag,
     },
   },
 };
@@ -343,6 +345,7 @@ export default [
       ],
       ...testFunctionalRules,
       'custom-rules/no-unnecessary-pipe-wrapper': 'error',
+      'custom-rules/prefer-match-tag': 'error',
     },
   },
   {
@@ -368,6 +371,7 @@ export default [
         ...simplePipeSyntaxRestrictions,
       ],
       'custom-rules/no-unnecessary-pipe-wrapper': 'error',
+      'custom-rules/prefer-match-tag': 'error',
     },
   },
   {
@@ -382,6 +386,7 @@ export default [
         ...simplePipeSyntaxRestrictions,
       ],
       'custom-rules/no-unnecessary-pipe-wrapper': 'error',
+      'custom-rules/prefer-match-tag': 'error',
     },
   },
   {
@@ -397,6 +402,7 @@ export default [
         ...simplePipeSyntaxRestrictions,
       ],
       'custom-rules/no-unnecessary-pipe-wrapper': 'error',
+      'custom-rules/prefer-match-tag': 'error',
     },
   },
   {

--- a/packages/eslint-test-rules/src/tag-rule-test.ts
+++ b/packages/eslint-test-rules/src/tag-rule-test.ts
@@ -1,4 +1,4 @@
-import { Either, Option, Effect, pipe } from 'effect';
+import { Either, Option, Effect, pipe, Match } from 'effect';
 
 const either = Either.right(42);
 const option = Option.some(42);
@@ -172,3 +172,22 @@ const unnecessaryFunctionExpr = function (value: number) {
   // eslint-disable-next-line custom-rules/no-unnecessary-pipe-wrapper -- Testing unnecessary function expression pipe wrapper
   return pipe(value, Effect.succeed);
 };
+
+// ========================================
+// MATCH.WHEN WITH _TAG (should fail - use Match.tag)
+// ========================================
+
+type MyResult =
+  | { readonly _tag: 'Success'; readonly value: number }
+  | { readonly _tag: 'Failure'; readonly error: string };
+
+const matchWithTagTest = (result: MyResult) =>
+  pipe(
+    result,
+    Match.value,
+    // eslint-disable-next-line custom-rules/prefer-match-tag -- Testing Match.when with _tag ban
+    Match.when({ _tag: 'Success' }, (res) => res.value),
+    // eslint-disable-next-line custom-rules/prefer-match-tag -- Testing Match.when with _tag ban
+    Match.when({ _tag: 'Failure' }, (res) => 0),
+    Match.exhaustive
+  );

--- a/packages/eventsourcing-protocol/src/lib/server-protocol.ts
+++ b/packages/eventsourcing-protocol/src/lib/server-protocol.ts
@@ -136,13 +136,13 @@ const buildResultMessage = (
   pipe(
     result,
     Match.value,
-    Match.when({ _tag: 'Success' }, (res) => ({
+    Match.tag('Success', (res) => ({
       type: 'command_result' as const,
       commandId,
       success: true,
       position: res.position,
     })),
-    Match.when({ _tag: 'Failure' }, (res) => ({
+    Match.tag('Failure', (res) => ({
       type: 'command_result' as const,
       commandId,
       success: false,


### PR DESCRIPTION
## Summary
- Added custom ESLint rule `prefer-match-tag` that enforces using `Match.tag()` instead of `Match.when()` when matching on `_tag` discriminators
- Applied auto-fix across the codebase to use the more type-safe pattern
- Added comprehensive tests for the new rule

## Benefits
- Better type safety when working with discriminated unions
- Clearer intent when matching on tagged types
- Consistent codebase patterns for Effect matching

## Changes
- New ESLint rule with auto-fix support in `eslint-rules/prefer-match-tag.js`
- Updated ESLint config to enable the rule across all packages
- Refactored `eventsourcing-protocol` to use `Match.tag()` pattern
- Added test cases to verify rule enforcement

## Testing
- All 69 tasks passing (tests, type checks, linting)
- New rule tested via eslint-test-rules package