### PR TITLE
fix(ci): prevent duplicate workflow runs

### DIFF
--- a/.changeset/fix-duplicate-ci-runs.md
+++ b/.changeset/fix-duplicate-ci-runs.md
@@ -1,0 +1,19 @@
+---
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
+'@codeforbreakfast/buntest': patch
+'@codeforbreakfast/eslint-effect': patch
+'@codeforbreakfast/eslint-test-rules': patch
+---
+
+CI workflow now uses concurrency groups to prevent duplicate workflow runs when the release bot updates PRs. This eliminates wasted compute resources from race conditions in GitHub's API-based commit handling.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Build, Lint and Test


### PR DESCRIPTION
## Summary

Fixes duplicate CI workflow runs that occur when the release bot updates PRs using `commitMode: 'github-api'`.

## Problem

When the changesets action uses GitHub's API to create commits (for verified commits), it triggers duplicate `pull_request` events for the same commit. This causes the CI workflow to execute twice unnecessarily, wasting compute resources.

## Solution

Added a concurrency group to the CI workflow keyed by workflow name and PR number. When duplicate events fire, the second run automatically cancels the first, ensuring only one CI run executes per PR at a time.

## Benefits

- Eliminates wasted CI runs
- Preserves verified commits from the release bot
- Standard pattern for handling GitHub API race conditions

## Test Plan

- [x] All checks pass locally
- [ ] Verify CI runs only once when release bot updates PR
- [ ] Confirm verified commits still work