### PR TITLE
feat(eslint-effect): expose syntax restrictions as named ESLint rules

### DIFF
--- a/.changeset/named-eslint-rules.md
+++ b/.changeset/named-eslint-rules.md
@@ -1,0 +1,45 @@
+---
+'@codeforbreakfast/eslint-effect': minor
+---
+
+Expose syntax restrictions as named ESLint rules for easier configuration
+
+Rules previously bundled in `no-restricted-syntax` are now available as individual named rules that can be easily enabled or disabled:
+
+**New named rules:**
+
+- `effect/no-classes` - Forbid classes except Effect tags/errors/schemas
+- `effect/no-runSync` - Forbid Effect.runSync in production code
+- `effect/no-runPromise` - Forbid Effect.runPromise in production code
+- `effect/prefer-andThen` - Prefer Effect.andThen() over Effect.flatMap(() => ...)
+- `effect/prefer-as` - Prefer Effect.as() over Effect.map(() => value)
+- `effect/no-gen` - Forbid Effect.gen (used in `noGen` config)
+
+**Before:**
+
+```javascript
+// Had to manipulate no-restricted-syntax arrays
+rules: {
+  'no-restricted-syntax': [
+    'error',
+    ...effectPlugin.configs.recommended.rules['no-restricted-syntax']
+      .slice(1)
+      .filter(restriction => ...)
+  ]
+}
+```
+
+**After:**
+
+```javascript
+// Simply disable by rule name
+{
+  ...effectPlugin.configs.recommended,
+  rules: {
+    'effect/no-runPromise': 'off',
+    'effect/no-runSync': 'off',
+  }
+}
+```
+
+This makes it much easier to customize which rules are enabled for different file patterns (e.g., allowing `runPromise` in application entry points while forbidding it in library code).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -159,14 +159,14 @@ export default [
     languageOptions: commonLanguageOptions,
     plugins: commonPluginsWithFunctional,
     rules: {
+      ...effectPlugin.configs.strict.rules,
       ...testFileImportRestrictions,
       'no-restricted-syntax': [
         'error',
         ...testSyntaxRestrictions,
-        ...effectPlugin.configs.pipeStrict.rules['no-restricted-syntax'].slice(1),
+        ...effectPlugin.configs.syntaxRestrictions.pipeStrict,
       ],
       ...testFunctionalRules,
-      ...effectPlugin.configs.strict.rules,
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,6 +94,12 @@ const testingContractsExceptionRules = {
   'functional/type-declaration-immutability': 'off',
   'no-restricted-imports': 'off',
   'no-restricted-syntax': 'off',
+  'effect/prefer-andThen': 'off',
+  'effect/prefer-as': 'off',
+  'effect/no-classes': 'off',
+  'effect/no-gen': 'off',
+  'effect/no-runSync': 'off',
+  'effect/no-runPromise': 'off',
 };
 
 // Common TypeScript rules

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,14 +47,6 @@ const functionalPluginOnly = {
   functional: functionalPlugin,
 };
 
-// Shared effect custom rules to avoid repetition
-const effectCustomRules = {
-  'effect/no-unnecessary-pipe-wrapper': 'error',
-  'effect/prefer-match-tag': 'error',
-  'effect/prefer-match-over-conditionals': 'error',
-  'effect/prefer-schema-validation-over-assertions': 'error',
-};
-
 // Test-specific configurations defined locally (consumers configure these as needed)
 // TODO: These should be exported from @codeforbreakfast/buntest package
 const testSyntaxRestrictions = [
@@ -141,7 +133,7 @@ export default [
     rules: typescriptBaseRules,
   },
   {
-    name: 'effect-coding-standards',
+    ...effectPlugin.configs.recommended,
     files: [
       '**/*.ts',
       '**/*.tsx',
@@ -151,10 +143,6 @@ export default [
       '**/*.spec.tsx',
     ],
     languageOptions: commonLanguageOptions,
-    plugins: typescriptPlugin,
-    rules: {
-      'no-restricted-syntax': ['error', ...effectPlugin.configs.effectSyntaxRestrictions],
-    },
   },
   {
     name: 'buntest-integration',
@@ -174,12 +162,11 @@ export default [
       ...testFileImportRestrictions,
       'no-restricted-syntax': [
         'error',
-        ...effectPlugin.configs.effectSyntaxRestrictions,
         ...testSyntaxRestrictions,
-        ...effectPlugin.configs.simplePipeSyntaxRestrictions,
+        ...effectPlugin.configs.pipeStrict.rules['no-restricted-syntax'].slice(1),
       ],
       ...testFunctionalRules,
-      ...effectCustomRules,
+      ...effectPlugin.configs.strict.rules,
     },
   },
   {
@@ -193,32 +180,28 @@ export default [
     rules: testingContractsExceptionRules,
   },
   {
-    name: 'simple-pipes',
+    ...effectPlugin.configs.noGen,
     files: ['packages/**/*.ts', 'packages/**/*.tsx'],
     ignores: ['**/buntest/**', '**/eventsourcing-testing-contracts/**'],
     languageOptions: commonLanguageOptions,
-    plugins: commonPlugins,
-    rules: {
-      'no-restricted-syntax': [
-        'error',
-        ...effectPlugin.configs.effectSyntaxRestrictions,
-        ...effectPlugin.configs.simplePipeSyntaxRestrictions,
-      ],
-      ...effectCustomRules,
-    },
   },
   {
-    name: 'scripts-production-rules',
+    ...effectPlugin.configs.pipeStrict,
+    files: ['packages/**/*.ts', 'packages/**/*.tsx'],
+    ignores: ['**/buntest/**', '**/eventsourcing-testing-contracts/**'],
+    languageOptions: commonLanguageOptions,
+  },
+  {
+    name: 'scripts-strict-with-runPromise-allowed',
     files: ['scripts/**/*.ts'],
     languageOptions: commonLanguageOptions,
-    plugins: commonPlugins,
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        ...effectPlugin.configs.effectSyntaxRestrictions,
-        ...effectPlugin.configs.simplePipeSyntaxRestrictions,
-      ],
-      ...effectCustomRules,
+      ...effectPlugin.configs.recommended.rules,
+      ...effectPlugin.configs.noGen.rules,
+      ...effectPlugin.configs.pipeStrict.rules,
+      // Allow runPromise/runSync in scripts as they are application entry points
+      'effect/no-runPromise': 'off',
+      'effect/no-runSync': 'off',
     },
   },
   {
@@ -228,12 +211,7 @@ export default [
     plugins: commonPlugins,
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
-      'no-restricted-syntax': [
-        'error',
-        ...effectPlugin.configs.effectSyntaxRestrictions,
-        ...effectPlugin.configs.simplePipeSyntaxRestrictions,
-      ],
-      ...effectCustomRules,
+      ...effectPlugin.configs.strict.rules,
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,9 @@ export default [
     rules: {
       ...effectPlugin.configs.strict.rules,
       ...testFileImportRestrictions,
+      // Override runPromise/runSync rules for tests - they use it.effect() instead
+      'effect/no-runPromise': 'off',
+      'effect/no-runSync': 'off',
       'no-restricted-syntax': [
         'error',
         ...testSyntaxRestrictions,

--- a/packages/eslint-effect/src/configs.js
+++ b/packages/eslint-effect/src/configs.js
@@ -219,3 +219,8 @@ export const pipeStrict = () => ({
   name: '@codeforbreakfast/eslint-effect/pipe-strict',
   rules: pipeStrictRulesOnly,
 });
+
+// Export raw restriction arrays for advanced use cases
+export const syntaxRestrictions = {
+  pipeStrict: pipeStrictRestrictions,
+};

--- a/packages/eslint-effect/src/index.js
+++ b/packages/eslint-effect/src/index.js
@@ -7,6 +7,7 @@ import {
   noGen,
   preferMatch,
   pipeStrict,
+  syntaxRestrictions,
 } from './configs.js';
 
 const plugin = {
@@ -25,9 +26,10 @@ const configs = {
   noGen: noGen(),
   preferMatch: preferMatch(),
   pipeStrict: pipeStrict(),
+  syntaxRestrictions,
 };
 
-export { rules, functionalImmutabilityRules };
+export { rules, functionalImmutabilityRules, syntaxRestrictions };
 
 export default {
   ...plugin,

--- a/packages/eslint-effect/src/index.js
+++ b/packages/eslint-effect/src/index.js
@@ -1,22 +1,35 @@
 import rules from './rules/index.js';
 import {
-  effectSyntaxRestrictions,
-  simplePipeSyntaxRestrictions,
   functionalImmutabilityRules,
+  pluginRules,
+  recommended,
+  strict,
+  noGen,
+  preferMatch,
+  pipeStrict,
 } from './configs.js';
 
-export {
+const plugin = {
   rules,
-  effectSyntaxRestrictions,
-  simplePipeSyntaxRestrictions,
-  functionalImmutabilityRules,
+  meta: {
+    name: '@codeforbreakfast/eslint-effect',
+    version: '0.2.0',
+  },
 };
 
+const configs = {
+  functionalImmutabilityRules,
+  plugin: pluginRules(),
+  recommended: recommended(),
+  strict: strict(),
+  noGen: noGen(),
+  preferMatch: preferMatch(),
+  pipeStrict: pipeStrict(),
+};
+
+export { rules, functionalImmutabilityRules };
+
 export default {
-  rules,
-  configs: {
-    effectSyntaxRestrictions,
-    simplePipeSyntaxRestrictions,
-    functionalImmutabilityRules,
-  },
+  ...plugin,
+  configs,
 };

--- a/packages/eslint-effect/src/rules/index.js
+++ b/packages/eslint-effect/src/rules/index.js
@@ -2,10 +2,22 @@ import noUnnecessaryPipeWrapper from './no-unnecessary-pipe-wrapper.js';
 import preferMatchTag from './prefer-match-tag.js';
 import preferMatchOverConditionals from './prefer-match-over-conditionals.js';
 import preferSchemaValidationOverAssertions from './prefer-schema-validation-over-assertions.js';
+import noClasses from './no-classes.js';
+import noRunSync from './no-runSync.js';
+import noRunPromise from './no-runPromise.js';
+import preferAndThen from './prefer-andThen.js';
+import preferAs from './prefer-as.js';
+import noGen from './no-gen.js';
 
 export default {
   'no-unnecessary-pipe-wrapper': noUnnecessaryPipeWrapper,
   'prefer-match-tag': preferMatchTag,
   'prefer-match-over-conditionals': preferMatchOverConditionals,
   'prefer-schema-validation-over-assertions': preferSchemaValidationOverAssertions,
+  'no-classes': noClasses,
+  'no-runSync': noRunSync,
+  'no-runPromise': noRunPromise,
+  'prefer-andThen': preferAndThen,
+  'prefer-as': preferAs,
+  'no-gen': noGen,
 };

--- a/packages/eslint-effect/src/rules/no-classes.js
+++ b/packages/eslint-effect/src/rules/no-classes.js
@@ -1,0 +1,62 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid classes except Effect service tags, error classes, and Schema classes',
+    },
+    messages: {
+      noClasses:
+        'Classes are forbidden in functional programming. Only Effect service tags (extending Context.Tag, Effect.Tag, or Context.GenericTag), error classes (extending Data.TaggedError), and Schema classes (extending Schema.Class) are allowed.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      ClassDeclaration(node) {
+        const hasAllowedExtension = node.body.body.some((member) => {
+          if (member.type === 'MethodDefinition' && member.kind === 'constructor') {
+            return member.value.body.body.some((statement) => {
+              if (
+                statement.type === 'ExpressionStatement' &&
+                statement.expression.type === 'CallExpression' &&
+                statement.expression.callee.type === 'Super'
+              ) {
+                return true;
+              }
+              return false;
+            });
+          }
+          return false;
+        });
+
+        const superClass = node.superClass;
+        if (superClass && superClass.type === 'MemberExpression') {
+          const object = superClass.object?.name;
+          const property = superClass.property?.name;
+
+          const allowedClasses = [
+            { object: 'Data', property: 'TaggedError' },
+            { object: 'Context', property: 'Tag' },
+            { object: 'Effect', property: 'Tag' },
+            { object: 'Context', property: 'GenericTag' },
+            { object: 'Schema', property: 'Class' },
+          ];
+
+          const isAllowed = allowedClasses.some(
+            (allowed) => object === allowed.object && property === allowed.property
+          );
+
+          if (isAllowed) {
+            return;
+          }
+        }
+
+        context.report({
+          node,
+          messageId: 'noClasses',
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/src/rules/no-classes.js
+++ b/packages/eslint-effect/src/rules/no-classes.js
@@ -18,9 +18,9 @@ export default {
 
         // Check for allowed patterns:
         // 1. MemberExpression: extends Data.TaggedError, Schema.Class
-        // 2. CallExpression: extends Context.Tag(...), Effect.Tag(...)
+        // 2. CallExpression: extends Context.Tag(...), Effect.Tag(...), Data.TaggedError(...), Schema.Class(...)
         if (superClass) {
-          // Pattern: extends Data.TaggedError or Schema.Class
+          // Pattern: extends Data.TaggedError or Schema.Class (direct member expression)
           if (superClass.type === 'MemberExpression') {
             const object = superClass.object?.name;
             const property = superClass.property?.name;
@@ -39,26 +39,46 @@ export default {
             }
           }
 
-          // Pattern: extends Context.Tag(...), Effect.Tag(...), Context.GenericTag(...)
-          if (
-            superClass.type === 'CallExpression' &&
-            superClass.callee.type === 'MemberExpression'
-          ) {
-            const object = superClass.callee.object?.name;
-            const property = superClass.callee.property?.name;
+          // Pattern: extends Context.Tag(...), Effect.Tag(...), Data.TaggedError(...), Schema.Class(...)
+          // Can be: Context.Tag(...)() or Context.Tag(...)<T>()
+          if (superClass.type === 'CallExpression') {
+            let callee = superClass.callee;
 
             const allowedCallExpressions = [
               { object: 'Context', property: 'Tag' },
               { object: 'Effect', property: 'Tag' },
               { object: 'Context', property: 'GenericTag' },
+              { object: 'Data', property: 'TaggedError' },
+              { object: 'Schema', property: 'Class' },
             ];
 
-            const isAllowed = allowedCallExpressions.some(
-              (allowed) => object === allowed.object && property === allowed.property
-            );
+            // Handle generic instantiation: Context.Tag(...)<T>()
+            // The callee might be a CallExpression with type parameters
+            if (callee.type === 'CallExpression' && callee.callee?.type === 'MemberExpression') {
+              const object = callee.callee.object?.name;
+              const property = callee.callee.property?.name;
 
-            if (isAllowed) {
-              return;
+              const isAllowed = allowedCallExpressions.some(
+                (allowed) => object === allowed.object && property === allowed.property
+              );
+
+              if (isAllowed) {
+                return;
+              }
+            }
+
+            // Handle direct call: Context.Tag()(...)  or Data.TaggedError('...')<T>
+            if (callee.type === 'MemberExpression') {
+              const object = callee.object?.name;
+              const property = callee.property?.name;
+
+              const isAllowed = allowedCallExpressions.some(
+                (allowed) => object === allowed.object && property === allowed.property
+              );
+
+              if (isAllowed) {
+                return;
+              }
             }
           }
         }

--- a/packages/eslint-effect/src/rules/no-gen.js
+++ b/packages/eslint-effect/src/rules/no-gen.js
@@ -1,0 +1,31 @@
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Forbid Effect.gen in favor of pipe composition',
+    },
+    messages: {
+      noGen: 'Effect.gen is forbidden. Use pipe and Effect.all/Effect.forEach instead.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Effect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'gen'
+        ) {
+          context.report({
+            node,
+            messageId: 'noGen',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/src/rules/no-runPromise.js
+++ b/packages/eslint-effect/src/rules/no-runPromise.js
@@ -1,0 +1,32 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid Effect.runPromise in production code',
+    },
+    messages: {
+      noRunPromise:
+        'Effect.runPromise is forbidden in production code. Effects should be composed and run at the application boundary.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Effect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'runPromise'
+        ) {
+          context.report({
+            node,
+            messageId: 'noRunPromise',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/src/rules/no-runSync.js
+++ b/packages/eslint-effect/src/rules/no-runSync.js
@@ -1,0 +1,32 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Forbid Effect.runSync in production code',
+    },
+    messages: {
+      noRunSync:
+        'Effect.runSync is forbidden in production code. Effects should be composed and run at the application boundary.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Effect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'runSync'
+        ) {
+          context.report({
+            node,
+            messageId: 'noRunSync',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/src/rules/prefer-andThen.js
+++ b/packages/eslint-effect/src/rules/prefer-andThen.js
@@ -1,0 +1,35 @@
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer Effect.andThen() over Effect.flatMap(() => ...)',
+    },
+    messages: {
+      preferAndThen:
+        'Use Effect.andThen() when discarding the input value. Effect.flatMap(() => expr) should be Effect.andThen(expr).',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Effect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'flatMap' &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === 'ArrowFunctionExpression' &&
+          node.arguments[0].params.length === 0
+        ) {
+          context.report({
+            node,
+            messageId: 'preferAndThen',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/src/rules/prefer-as.js
+++ b/packages/eslint-effect/src/rules/prefer-as.js
@@ -1,0 +1,35 @@
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer Effect.as() over Effect.map(() => value)',
+    },
+    messages: {
+      preferAs:
+        'Use Effect.as() when replacing with a constant value. Effect.map(() => value) should be Effect.as(value).',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'Effect' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'map' &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === 'ArrowFunctionExpression' &&
+          node.arguments[0].params.length === 0
+        ) {
+          context.report({
+            node,
+            messageId: 'preferAs',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-effect/test/tag-rule-test.ts
+++ b/packages/eslint-effect/test/tag-rule-test.ts
@@ -37,7 +37,7 @@ if ('Right' === either._tag) {
 // EFFECT.GEN RULES (should fail)
 // ========================================
 
-// eslint-disable-next-line no-restricted-syntax -- Testing Effect.gen call
+// eslint-disable-next-line effect/no-gen -- Testing Effect.gen call
 const genTest = Effect.gen(function* () {
   yield* Effect.succeed(42);
   return 'done';
@@ -50,7 +50,7 @@ const genRef = Effect.gen;
 // CLASSES RULES (should fail)
 // ========================================
 
-// eslint-disable-next-line no-restricted-syntax -- Testing class restriction
+// eslint-disable-next-line effect/no-classes -- Testing class restriction
 class MyClass {
   // eslint-disable-next-line functional/prefer-immutable-types, functional/prefer-readonly-type -- Testing class property rules
   value = 42;
@@ -60,10 +60,10 @@ class MyClass {
 // EFFECT.RUNSYNC / RUNPROMISE (should fail in production)
 // ========================================
 
-// eslint-disable-next-line no-restricted-syntax -- Testing Effect.runSync ban
+// eslint-disable-next-line effect/no-runSync -- Testing Effect.runSync ban
 Effect.runSync(Effect.succeed(42));
 
-// eslint-disable-next-line no-restricted-syntax -- Testing Effect.runPromise ban
+// eslint-disable-next-line effect/no-runPromise -- Testing Effect.runPromise ban
 Effect.runPromise(Effect.succeed(42));
 
 // ========================================
@@ -129,13 +129,13 @@ const firstArgFnCall = pipe(
 // ========================================
 
 // Direct call without pipe
-// eslint-disable-next-line no-restricted-syntax -- Testing flatMap with discarded input
+// eslint-disable-next-line effect/prefer-andThen -- Testing flatMap with discarded input
 const flatMapDirect = Effect.flatMap(() => Effect.succeed('hello'));
 
 const flatMapDiscarded = pipe(
   // eslint-disable-next-line no-restricted-syntax -- Testing first arg in pipe
   Effect.succeed(42),
-  // eslint-disable-next-line no-restricted-syntax -- Testing flatMap with discarded input
+  // eslint-disable-next-line effect/prefer-andThen -- Testing flatMap with discarded input
   Effect.flatMap(() => Effect.succeed('hello'))
 );
 
@@ -144,13 +144,13 @@ const flatMapDiscarded = pipe(
 // ========================================
 
 // Direct call without pipe
-// eslint-disable-next-line no-restricted-syntax -- Testing map with constant value
+// eslint-disable-next-line effect/prefer-as -- Testing map with constant value
 const mapDirect = Effect.map(() => 'constant');
 
 const mapConstant = pipe(
   // eslint-disable-next-line no-restricted-syntax -- Testing first arg in pipe
   Effect.succeed(42),
-  // eslint-disable-next-line no-restricted-syntax -- Testing map with constant value
+  // eslint-disable-next-line effect/prefer-as -- Testing map with constant value
   Effect.map(() => 'constant')
 );
 

--- a/packages/eventsourcing-transport-websocket/src/lib/websocket-server.ts
+++ b/packages/eventsourcing-transport-websocket/src/lib/websocket-server.ts
@@ -360,7 +360,7 @@ const createWebSocketServer = (
                 connectedAt: new Date(),
               }));
 
-            // eslint-disable-next-line no-restricted-syntax -- WebSocket open handler is a synchronous callback at application boundary, requires Effect.runSync
+            // eslint-disable-next-line effect/no-runSync -- WebSocket open handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 createClientIdAndTimestamp(),
@@ -376,7 +376,7 @@ const createWebSocketServer = (
             ws: ReadonlyDeep<ServerWebSocket<{ readonly clientId: Server.ClientId }>>,
             message: ReadonlyDeep<string>
           ) => {
-            // eslint-disable-next-line no-restricted-syntax -- WebSocket message handler is a synchronous callback at application boundary, requires Effect.runSync
+            // eslint-disable-next-line effect/no-runSync -- WebSocket message handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 serverStateRef,
@@ -390,7 +390,7 @@ const createWebSocketServer = (
           },
 
           close: (ws: ReadonlyDeep<ServerWebSocket<{ readonly clientId: Server.ClientId }>>) => {
-            // eslint-disable-next-line no-restricted-syntax -- WebSocket close handler is a synchronous callback at application boundary, requires Effect.runSync
+            // eslint-disable-next-line effect/no-runSync -- WebSocket close handler is a synchronous callback at application boundary, requires Effect.runSync
             Effect.runSync(
               pipe(
                 serverStateRef,

--- a/scripts/validate-markdown-examples.ts
+++ b/scripts/validate-markdown-examples.ts
@@ -550,7 +550,6 @@ const logErrorAndFail = (error: Readonly<Error>) => {
 
 const program = pipe(validateMarkdownExamples, Effect.catchAll(logErrorAndFail));
 
-// eslint-disable-next-line no-restricted-syntax -- Script entry point: runPromise is acceptable at application boundary
 Effect.runPromise(program)
   .then(() => process.exit(0))
   .catch(() => process.exit(1));


### PR DESCRIPTION
## Summary

Convert `no-restricted-syntax` restrictions to individual named ESLint rules for easier configuration and better developer experience.

## Changes

**New named rules:**
- `effect/no-classes` - Forbid classes except Effect tags/errors/schemas
- `effect/no-runSync` - Forbid Effect.runSync in production code
- `effect/no-runPromise` - Forbid Effect.runPromise in production code
- `effect/prefer-andThen` - Prefer Effect.andThen() over Effect.flatMap(() => ...)
- `effect/prefer-as` - Prefer Effect.as() over Effect.map(() => value)
- `effect/no-gen` - Forbid Effect.gen (used in `noGen` config)

## Benefits

1. **Easier to disable individual rules** - Just use the rule name
2. **Better error messages** - Each rule has its own message ID
3. **Cleaner config** - No need to understand no-restricted-syntax arrays
4. **IDE support** - Named rules show up properly in IDE hints
5. **Future-proof** - Easier to add rule options/configs later

## Before/After

**Before:**
```javascript
// Had to manipulate no-restricted-syntax arrays
rules: {
  'no-restricted-syntax': [
    'error',
    ...effectPlugin.configs.recommended.rules['no-restricted-syntax']
      .slice(1)
      .filter(restriction => ...)
  ]
}
```

**After:**
```javascript
// Simply disable by rule name
{
  ...effectPlugin.configs.recommended,
  rules: {
    'effect/no-runPromise': 'off',
    'effect/no-runSync': 'off',
  }
}
```