### PR TITLE
feat: add manual publish workflow using NPM_TOKEN

### DIFF
--- a/.github/workflows/publish-with-token.yml
+++ b/.github/workflows/publish-with-token.yml
@@ -3,11 +3,6 @@ name: Manual Publish with NPM Token
 
 on:
   workflow_dispatch:
-    inputs:
-      reason:
-        description: 'Reason for manual publish (e.g., first-time package publish)'
-        required: true
-        type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -40,8 +35,6 @@ jobs:
       - name: Summary
         run: |
           echo "## Manual Publish Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Reason:** ${{ inputs.reason }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Packages were published using NPM_TOKEN authentication." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-with-token.yml
+++ b/.github/workflows/publish-with-token.yml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Manual Publish with NPM Token
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual publish (e.g., first-time package publish)'
+        required: true
+        type: string
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish packages using NPM_TOKEN
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          turbo-cache-key: 'manual-publish'
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Publish to npm
+        run: bunx changeset publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Manual Publish Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Reason:** ${{ inputs.reason }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Packages were published using NPM_TOKEN authentication." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ **Next Steps:**" >> $GITHUB_STEP_SUMMARY
+          echo "1. Configure OIDC trusted publishing for newly published packages on npmjs.com" >> $GITHUB_STEP_SUMMARY
+          echo "2. Future releases will use OIDC via the regular release workflow" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that can manually publish packages using NPM_TOKEN instead of OIDC.

## Why?

npm OIDC trusted publishing cannot publish packages for the first time - it requires the package to already exist on npm before OIDC can be configured. This workflow solves that limitation.

## How it works

- Manually triggered from GitHub Actions UI
- Uses `NPM_TOKEN` for authentication
- Runs `changeset publish` which automatically detects unpublished versions
- Only publishes packages that need publishing (based on package.json vs npm registry)

## Use case

Currently needed to publish `@codeforbreakfast/eslint-effect@0.3.1` for the first time.

## Next steps after using this workflow

1. Configure OIDC trusted publishing for newly published packages on npmjs.com
2. Future releases will use OIDC via the regular release workflow
3. This workflow can be kept for emergency use or deleted

## Related

- npm CLI issue: https://github.com/npm/cli/issues/8544