### PR TITLE
fix: add .npmrc configuration for npm authentication

### DIFF
--- a/.github/workflows/publish-with-token.yml
+++ b/.github/workflows/publish-with-token.yml
@@ -26,10 +26,15 @@ jobs:
       - name: Build packages
         run: bun run build
 
+      - name: Configure npm authentication
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+          //registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}
+          EOF
+
       - name: Publish to npm
         run: bunx changeset publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary


### PR DESCRIPTION
Fixes the ENEEDAUTH error in the manual publish workflow by creating an ~/.npmrc file that references NODE_AUTH_TOKEN.