### PR TITLE
docs(eslint-effect): add changeset for new eta-expansion and alias rules

### DIFF
--- a/.changeset/add-eta-expansion-and-alias-rules.md
+++ b/.changeset/add-eta-expansion-and-alias-rules.md
@@ -1,0 +1,11 @@
+---
+'@codeforbreakfast/eslint-effect': minor
+---
+
+Added two new ESLint rules to enforce functional programming best practices:
+
+- `no-eta-expansion` - Detects unnecessary function wrappers (eta-expansion) that only pass parameters directly to another function. Encourages point-free style by flagging patterns like `(x) => fn(x)` which can be simplified to just `fn`. This helps reduce code noise and improve readability in functional compositions.
+
+- `no-unnecessary-function-alias` - Detects unnecessary function aliases that provide no semantic value. When a constant is assigned directly to another function without adding clarity or abstraction, it should be inlined at the call site. The rule is configurable with a `maxReferences` option to allow aliases that improve code reuse.
+
+Both rules are included in the recommended configuration and support ESLint's disable comments for legitimate use cases where the expanded form adds necessary clarity.


### PR DESCRIPTION
## Summary

- Added missing changeset for the `no-eta-expansion` and `no-unnecessary-function-alias` rules added in #228
- These rules were added to the package but the changeset only documented the refactoring work
- This ensures the new rules are properly documented in the package's changelog

## Why

PR #228 added two new ESLint rules to enforce functional programming patterns, but the changeset only covered the refactoring changes made using those rules, not the rule additions themselves. This left the eslint-effect package missing changelog entries for the new functionality.

## Test plan

- [x] All tests pass (`turbo all`)
- [x] Changeset follows semantic versioning (minor bump for new features)
- [x] Changeset describes changes from user perspective