### PR TITLE
fix(eslint-effect): exclude computed member expressions from alias rule

### DIFF
--- a/.changeset/fix-computed-member-alias.md
+++ b/.changeset/fix-computed-member-alias.md
@@ -1,0 +1,7 @@
+---
+'@codeforbreakfast/eslint-effect': patch
+---
+
+Fix no-unnecessary-function-alias rule to allow computed member expressions
+
+The rule now correctly excludes aliases for computed member expressions (bracket notation) like `const firstEvent = events[0]` or `const command = args[0]`. These aliases provide semantic value by giving meaningful names to array/object access patterns and should not be flagged as unnecessary.

--- a/packages/eslint-effect/src/rules/no-unnecessary-function-alias.js
+++ b/packages/eslint-effect/src/rules/no-unnecessary-function-alias.js
@@ -67,6 +67,10 @@ export default {
 
         if (!isDirectAlias) return;
 
+        if (node.init.type === 'MemberExpression' && node.init.computed) {
+          return;
+        }
+
         if (isExported(node.parent.parent)) return;
 
         const aliasName = node.id.name;

--- a/packages/eslint-effect/test/no-unnecessary-function-alias.test.ts
+++ b/packages/eslint-effect/test/no-unnecessary-function-alias.test.ts
@@ -49,6 +49,20 @@ const wrappedFunction = (x: number) => Effect.succeed(x * 2);
 const notAnAlias = (x: number) => wrappedFunction(x);
 
 // ============================================================================
+// SHOULD NOT TRIGGER - Computed member expressions add semantic value
+// ============================================================================
+
+const events = [{ type: 'created' }, { type: 'updated' }];
+const firstEvent = events[0];
+const secondEvent = events[1];
+
+const useIndexedAccess = () => {
+  if (!firstEvent) throw new Error('Expected first event');
+  if (!secondEvent) throw new Error('Expected second event');
+  return [firstEvent.type, secondEvent.type];
+};
+
+// ============================================================================
 // DEMONSTRATES THE RULE - This will trigger a warning
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes the `no-unnecessary-function-alias` rule to correctly handle computed member expressions (bracket notation).

Previously, the rule would incorrectly flag aliases like `const firstEvent = events[0]` or `const command = args[0]` as unnecessary. These aliases actually provide semantic value by giving meaningful names to array/object access patterns.

## Changes

- Modified `no-unnecessary-function-alias` rule to skip computed member expressions
- Added test cases demonstrating the fix

## Examples Now Allowed

```typescript
const firstEvent = events[0];  // ✓ Semantic value - describes what it is
const command = args[0];        // ✓ Semantic value - clearer intent
const item = collection[index]; // ✓ Semantic value - meaningful name
```

## Test Plan

- [x] Existing tests pass
- [x] New test cases added for computed member expressions
- [x] Verified on example codebase (todo-app)