### PR TITLE
fix(eslint-effect): exclude 'as const' from prefer-schema-validation-over-assertions rule

### DIFF
--- a/.changeset/fix-eslint-as-const.md
+++ b/.changeset/fix-eslint-as-const.md
@@ -1,0 +1,5 @@
+---
+'@codeforbreakfast/eslint-effect': patch
+---
+
+Fix `prefer-schema-validation-over-assertions` rule to allow safe `as const` type assertions. The rule now correctly distinguishes between unsafe type casts (which should use Schema validation) and safe const assertions used for literal type narrowing in discriminated unions.

--- a/packages/eslint-effect/src/rules/prefer-schema-validation-over-assertions.js
+++ b/packages/eslint-effect/src/rules/prefer-schema-validation-over-assertions.js
@@ -67,8 +67,22 @@ export default {
       return false;
     };
 
+    const isConstAssertion = (node) => {
+      return (
+        node.typeAnnotation &&
+        node.typeAnnotation.type === 'TSTypeReference' &&
+        node.typeAnnotation.typeName &&
+        node.typeAnnotation.typeName.type === 'Identifier' &&
+        node.typeAnnotation.typeName.name === 'const'
+      );
+    };
+
     return {
       TSAsExpression(node) {
+        if (isConstAssertion(node)) {
+          return;
+        }
+
         if (isInsideEffectCallback(node)) {
           context.report({
             node,

--- a/packages/eslint-effect/test/prefer-schema-validation-over-assertions.test.ts
+++ b/packages/eslint-effect/test/prefer-schema-validation-over-assertions.test.ts
@@ -52,3 +52,34 @@ const noTypeAssertion = pipe(
   Effect.succeed<ProtocolMessage>({ type: 'command', id: '123' }),
   Effect.map((msg) => msg.id)
 );
+
+// Should NOT fail - as const in Effect callback (safe literal type narrowing)
+const constAssertionInCallback = pipe(
+  // eslint-disable-next-line effect/no-pipe-first-arg-call -- Testing first arg in pipe
+  Effect.succeed(1),
+  Effect.as({ type: 'TodoCompleted' as const, data: { completedAt: new Date() } })
+);
+
+// Should NOT fail - as const in object within Effect.flatMap
+const constAssertionInFlatMap = pipe(
+  // eslint-disable-next-line effect/no-pipe-first-arg-call -- Testing first arg in pipe
+  Effect.succeed(true),
+  Effect.flatMap((completed) =>
+    completed
+      ? Effect.succeed([
+          {
+            type: 'TodoCompleted' as const,
+            metadata: { occurredAt: new Date() },
+            data: { completedAt: new Date() },
+          },
+        ])
+      : Effect.succeed([])
+  )
+);
+
+// Should NOT fail - as const for string literal
+const constAssertionStringLiteral = pipe(
+  // eslint-disable-next-line effect/no-pipe-first-arg-call -- Testing first arg in pipe
+  Effect.succeed('test'),
+  Effect.as('TodoCreated' as const)
+);


### PR DESCRIPTION
## Summary

Fixes the `prefer-schema-validation-over-assertions` ESLint rule to correctly exclude safe `as const` type assertions.

## Problem

The rule was flagging ALL `as` expressions in Effect callbacks, including safe `as const` assertions used for literal type narrowing in discriminated unions. This caused false positives when using patterns like:

```typescript
Effect.succeed([{
  type: 'TodoCompleted' as const,
  data: { completedAt: new Date() }
}])
```

## Solution

Added an `isConstAssertion` helper that checks if a TypeScript `as` expression is specifically an `as const` assertion. The rule now skips these safe assertions while still catching unsafe type casts that should use Schema validation.

## Test Plan

- Added test cases for `as const` in Effect callbacks
- Verified existing unsafe assertion tests still fail
- All checks passing