### PR TITLE
fix(renovate): include examples directory in dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "npm:unpublishSafe",
     ":semanticCommits"
   ],
+  "ignorePaths": ["**/node_modules/**", "**/test/**", "**/tests/**"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Summary

Fixes Renovate configuration to include the `examples/` directory in dependency updates.

## Problem

The `config:best-practices` preset extends `config:recommended`, which sets default `ignorePaths` that exclude `**/examples/**` along with test directories. This caused Renovate to skip updating dependencies in `examples/todo-app/package.json`.

For example, PR #236 updated Effect dependencies in all packages but missed the example app.

## Solution

Added explicit `ignorePaths` configuration to `renovate.json` that:
- ✅ Removes the `**/examples/**` pattern (Renovate will now process examples)
- ✅ Keeps ignoring `node_modules`, `test`, and `tests` directories
- ✅ Removed unnecessary patterns (`bower_components`, `vendor`, `__tests__`, `__fixtures__`) that don't exist in our codebase

## Impact

Future Renovate PRs will now include dependency updates for example applications, keeping them in sync with the published packages.

## Test Plan

- [x] All checks pass (`turbo all`)
- [x] Configuration follows JSON schema
- [ ] Next Renovate run should include `examples/todo-app/package.json` in Effect updates