### PR TITLE
chore(changesets): fix major version bump to minor

### DIFF
--- a/.changeset/fix-major-version-bump.md
+++ b/.changeset/fix-major-version-bump.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixed incorrect major version bump in changeset. Pre-1.0 packages use minor bumps for breaking changes per semver specification.

--- a/.changeset/provide-command-context.md
+++ b/.changeset/provide-command-context.md
@@ -1,5 +1,5 @@
 ---
-'@codeforbreakfast/eventsourcing-aggregates': major
+'@codeforbreakfast/eventsourcing-aggregates': minor
 '@codeforbreakfast/eventsourcing-transport-websocket': minor
 ---
 


### PR DESCRIPTION
## Summary

Fixed incorrect major version bump in the `provide-command-context.md` changeset. Since we're pre-1.0, breaking changes should use minor bumps according to semver specification.

## Changes

- Changed `@codeforbreakfast/eventsourcing-aggregates` from `major` to `minor` in `.changeset/provide-command-context.md`
- Added changeset documenting this fix

## Test plan

- ✅ All tests pass (`turbo all`)
- ✅ Changeset format validated