### PR TITLE
fix(ci): use PR head SHA for Turbo cache key to prevent cache misses

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,9 +37,9 @@ runs:
       with:
         path: |
           .turbo/cache
-        key: ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.turbo-cache-key }}-${{ github.sha }}
+        key: ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.turbo-cache-key }}-${{ github.event.pull_request.head.sha || github.sha }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.restore-turbo-cache-key }}-${{ github.sha }}
+          ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.restore-turbo-cache-key }}-${{ github.event.pull_request.head.sha || github.sha }}
           ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.turbo-cache-key }}-
           ${{ runner.os }}-${{ runner.arch }}-turbo-${{ inputs.restore-turbo-cache-key }}-
           ${{ runner.os }}-${{ runner.arch }}-turbo-

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,6 @@
         "@codeforbreakfast/eventsourcing-projections": "workspace:*",
         "@codeforbreakfast/eventsourcing-store": "workspace:*",
         "@codeforbreakfast/eventsourcing-store-filesystem": "workspace:*",
-        "@codeforbreakfast/eventsourcing-store-inmemory": "workspace:*",
         "@effect/platform-bun": "0.81.1",
         "effect": "3.18.4",
       },


### PR DESCRIPTION
## Problem

GitHub Actions creates merge commits when running PR checks (merging the PR branch with main). When main moves forward between PR runs, the merge commit SHA changes even if the PR code hasn't changed. This causes Turbo cache keys to change, resulting in complete cache misses.

Example from PR #244 (renovate config):
- Previous run: merge commit `d4acf7e...` 
- Current run: merge commit `b3744018...` (only `renovate.json` changed)
- Result: **103 Turbo cache misses** despite no real code changes

## Solution

Use `github.event.pull_request.head.sha` instead of `github.sha` for the Turbo cache key. This makes the cache key based on the actual PR commit, not the merge commit.

For non-PR workflows (pushes to main), it falls back to `github.sha`.

## Benefits

- PR cache remains stable across multiple runs
- Cache survives even when main moves forward between runs
- Significantly faster CI for PRs with no code changes
- Proper cache utilization for incremental changes

## Testing

All checks passed locally with `turbo all`.