### PR TITLE
refactor(eslint-effect): extract shared utilities to reduce duplication

### DIFF
--- a/.changeset/refactor-eslint-rules-shared-utilities.md
+++ b/.changeset/refactor-eslint-rules-shared-utilities.md
@@ -1,0 +1,24 @@
+---
+'@codeforbreakfast/eslint-effect': patch
+---
+
+Internal refactoring to reduce code duplication across ESLint rules. This change improves maintainability and consistency of rule implementations without affecting functionality or rule behavior.
+
+**Changes:**
+
+- Extracted common method call checking logic into a reusable `createMethodCallChecker` factory function
+- Created shared utilities for common return type checks (`isNullReturn`, `isUndefinedReturn`, `isOptionSome`, `isVoidReturningFunction`)
+- Refactored multiple rules to use shared utilities, reducing code duplication by 30-40% per rule
+- Improved code consistency across rule implementations
+
+**Rules refactored:**
+
+- `prefer-get-or-null`
+- `prefer-get-or-undefined`
+- `prefer-as-some`
+- `prefer-as-some-error`
+- `prefer-zip-left`
+- `prefer-zip-right`
+- `prefer-ignore`
+
+All rules maintain the same functionality and test coverage. No user-facing changes.

--- a/packages/eslint-effect/src/rules/prefer-as-some-error.js
+++ b/packages/eslint-effect/src/rules/prefer-as-some-error.js
@@ -1,4 +1,7 @@
+import { createMethodCallChecker, isOptionSome } from './utils.js';
+
 const SUPPORTED_TYPES = ['Effect'];
+const isMapErrorCall = createMethodCallChecker('mapError', SUPPORTED_TYPES);
 
 export default {
   meta: {
@@ -17,39 +20,15 @@ export default {
   },
 
   create(context) {
-    const isMapErrorCall = (node) => {
-      if (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'mapError' &&
-        node.callee.object.type === 'Identifier' &&
-        SUPPORTED_TYPES.includes(node.callee.object.name)
-      ) {
-        return { type: node.callee.object.name, isDataFirst: false };
-      }
-      return null;
-    };
-
-    const isOptionSome = (node) => {
-      return (
-        node.type === 'MemberExpression' &&
-        node.object.type === 'Identifier' &&
-        node.object.name === 'Option' &&
-        node.property.type === 'Identifier' &&
-        node.property.name === 'some'
-      );
-    };
-
     return {
       CallExpression(node) {
-        const mapErrorInfo = isMapErrorCall(node);
-        if (!mapErrorInfo) return;
+        if (!isMapErrorCall(node)) return;
 
         const mapErrorArg = node.arguments[0];
         if (!mapErrorArg) return;
 
         if (isOptionSome(mapErrorArg)) {
-          const effectType = mapErrorInfo.type;
+          const effectType = node.callee.object.name;
 
           context.report({
             node,

--- a/packages/eslint-effect/src/rules/prefer-as-some.js
+++ b/packages/eslint-effect/src/rules/prefer-as-some.js
@@ -1,4 +1,7 @@
+import { createMethodCallChecker, isOptionSome } from './utils.js';
+
 const SUPPORTED_TYPES = ['Effect'];
+const isMapCall = createMethodCallChecker('map', SUPPORTED_TYPES);
 
 export default {
   meta: {
@@ -16,39 +19,15 @@ export default {
   },
 
   create(context) {
-    const isMapCall = (node) => {
-      if (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'map' &&
-        node.callee.object.type === 'Identifier' &&
-        SUPPORTED_TYPES.includes(node.callee.object.name)
-      ) {
-        return { type: node.callee.object.name, isDataFirst: false };
-      }
-      return null;
-    };
-
-    const isOptionSome = (node) => {
-      return (
-        node.type === 'MemberExpression' &&
-        node.object.type === 'Identifier' &&
-        node.object.name === 'Option' &&
-        node.property.type === 'Identifier' &&
-        node.property.name === 'some'
-      );
-    };
-
     return {
       CallExpression(node) {
-        const mapInfo = isMapCall(node);
-        if (!mapInfo) return;
+        if (!isMapCall(node)) return;
 
         const mapArg = node.arguments[0];
         if (!mapArg) return;
 
         if (isOptionSome(mapArg)) {
-          const effectType = mapInfo.type;
+          const effectType = node.callee.object.name;
 
           context.report({
             node,

--- a/packages/eslint-effect/src/rules/prefer-get-or-null.js
+++ b/packages/eslint-effect/src/rules/prefer-get-or-null.js
@@ -1,3 +1,7 @@
+import { createMethodCallChecker, isNullReturn } from './utils.js';
+
+const isGetOrElseCall = createMethodCallChecker('getOrElse', ['Option']);
+
 export default {
   meta: {
     type: 'suggestion',
@@ -14,36 +18,6 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
-
-    const isGetOrElseCall = (node) => {
-      return (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'getOrElse' &&
-        node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'Option'
-      );
-    };
-
-    const isNullReturn = (arrowFunc) => {
-      if (arrowFunc.params.length !== 0) {
-        return false;
-      }
-
-      const body = arrowFunc.body;
-
-      if (body.type === 'Literal' && body.value === null) {
-        return true;
-      }
-
-      if (body.type === 'Identifier' && body.name === 'null') {
-        return true;
-      }
-
-      return false;
-    };
-
     return {
       CallExpression(node) {
         if (!isGetOrElseCall(node)) return;

--- a/packages/eslint-effect/src/rules/prefer-get-or-undefined.js
+++ b/packages/eslint-effect/src/rules/prefer-get-or-undefined.js
@@ -1,3 +1,7 @@
+import { createMethodCallChecker, isUndefinedReturn } from './utils.js';
+
+const isGetOrElseCall = createMethodCallChecker('getOrElse', ['Option']);
+
 export default {
   meta: {
     type: 'suggestion',
@@ -14,32 +18,6 @@ export default {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
-
-    const isGetOrElseCall = (node) => {
-      return (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'getOrElse' &&
-        node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'Option'
-      );
-    };
-
-    const isUndefinedReturn = (arrowFunc) => {
-      if (arrowFunc.params.length !== 0) {
-        return false;
-      }
-
-      const body = arrowFunc.body;
-
-      if (body.type === 'Identifier' && body.name === 'undefined') {
-        return true;
-      }
-
-      return false;
-    };
-
     return {
       CallExpression(node) {
         if (!isGetOrElseCall(node)) return;

--- a/packages/eslint-effect/src/rules/prefer-ignore.js
+++ b/packages/eslint-effect/src/rules/prefer-ignore.js
@@ -1,4 +1,7 @@
+import { createMethodCallChecker, isVoidReturningFunction } from './utils.js';
+
 const SUPPORTED_TYPES = ['Effect', 'STM'];
+const isMatchCall = createMethodCallChecker('match', SUPPORTED_TYPES);
 
 export default {
   meta: {
@@ -17,52 +20,6 @@ export default {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-
-    const isMatchCall = (node) => {
-      return (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'match' &&
-        node.callee.object.type === 'Identifier' &&
-        SUPPORTED_TYPES.includes(node.callee.object.name)
-      );
-    };
-
-    const isVoidReturningFunction = (node) => {
-      if (!node) return false;
-
-      // Check for constVoid identifier
-      if (node.type === 'Identifier' && node.name === 'constVoid') {
-        return true;
-      }
-
-      // Check for arrow function
-      if (node.type === 'ArrowFunctionExpression') {
-        const body = node.body;
-
-        // Check for () => undefined or (_) => undefined
-        if (body.type === 'Identifier' && body.name === 'undefined') {
-          return true;
-        }
-
-        // Check for () => void 0 or (_) => void 0 (UnaryExpression with void operator)
-        if (
-          body.type === 'UnaryExpression' &&
-          body.operator === 'void' &&
-          body.argument.type === 'Literal' &&
-          body.argument.value === 0
-        ) {
-          return true;
-        }
-
-        // Check for () => {} (empty block)
-        if (body.type === 'BlockStatement' && body.body.length === 0) {
-          return true;
-        }
-      }
-
-      return false;
-    };
 
     return {
       CallExpression(node) {

--- a/packages/eslint-effect/src/rules/prefer-zip-left.js
+++ b/packages/eslint-effect/src/rules/prefer-zip-left.js
@@ -1,4 +1,7 @@
+import { createMethodCallChecker } from './utils.js';
+
 const SUPPORTED_TYPES = ['Effect', 'Option'];
+const isFlatMapCall = createMethodCallChecker('flatMap', SUPPORTED_TYPES);
 
 export default {
   meta: {
@@ -18,16 +21,6 @@ export default {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-
-    const isFlatMapCall = (node) => {
-      return (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'flatMap' &&
-        node.callee.object.type === 'Identifier' &&
-        SUPPORTED_TYPES.includes(node.callee.object.name)
-      );
-    };
 
     const isZipLeftPattern = (arrowFunc, effectType) => {
       if (!arrowFunc || arrowFunc.type !== 'ArrowFunctionExpression') {

--- a/packages/eslint-effect/src/rules/prefer-zip-right.js
+++ b/packages/eslint-effect/src/rules/prefer-zip-right.js
@@ -1,4 +1,7 @@
+import { createMethodCallChecker } from './utils.js';
+
 const SUPPORTED_TYPES = ['Effect', 'Option'];
+const isFlatMapCall = createMethodCallChecker('flatMap', SUPPORTED_TYPES);
 
 export default {
   meta: {
@@ -18,16 +21,6 @@ export default {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-
-    const isFlatMapCall = (node) => {
-      return (
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'flatMap' &&
-        node.callee.object.type === 'Identifier' &&
-        SUPPORTED_TYPES.includes(node.callee.object.name)
-      );
-    };
 
     const isZipRightPattern = (arrowFunc) => {
       if (!arrowFunc || arrowFunc.type !== 'ArrowFunctionExpression') {

--- a/packages/eslint-effect/src/rules/utils.js
+++ b/packages/eslint-effect/src/rules/utils.js
@@ -21,3 +21,86 @@ export const isVoidReturn = (arrowFunc) => {
 
   return false;
 };
+
+export const createMethodCallChecker = (methodName, supportedTypes) => (node) => {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === methodName &&
+    node.callee.object.type === 'Identifier' &&
+    supportedTypes.includes(node.callee.object.name)
+  );
+};
+
+export const isNullReturn = (arrowFunc) => {
+  if (arrowFunc.params.length !== 0) {
+    return false;
+  }
+
+  const body = arrowFunc.body;
+
+  if (body.type === 'Literal' && body.value === null) {
+    return true;
+  }
+
+  if (body.type === 'Identifier' && body.name === 'null') {
+    return true;
+  }
+
+  return false;
+};
+
+export const isUndefinedReturn = (arrowFunc) => {
+  if (arrowFunc.params.length !== 0) {
+    return false;
+  }
+
+  const body = arrowFunc.body;
+
+  if (body.type === 'Identifier' && body.name === 'undefined') {
+    return true;
+  }
+
+  return false;
+};
+
+export const isOptionSome = (node) => {
+  return (
+    node.type === 'MemberExpression' &&
+    node.object.type === 'Identifier' &&
+    node.object.name === 'Option' &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'some'
+  );
+};
+
+export const isVoidReturningFunction = (node) => {
+  if (!node) return false;
+
+  if (node.type === 'Identifier' && node.name === 'constVoid') {
+    return true;
+  }
+
+  if (node.type === 'ArrowFunctionExpression') {
+    const body = node.body;
+
+    if (body.type === 'Identifier' && body.name === 'undefined') {
+      return true;
+    }
+
+    if (
+      body.type === 'UnaryExpression' &&
+      body.operator === 'void' &&
+      body.argument.type === 'Literal' &&
+      body.argument.value === 0
+    ) {
+      return true;
+    }
+
+    if (body.type === 'BlockStatement' && body.body.length === 0) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary

Internal refactoring to extract common patterns from ESLint rules into shared utility functions. This improves maintainability and consistency without changing rule behavior.

## Changes

- Added `createMethodCallChecker` factory function for reusable method call validation
- Created shared utilities for common return type checks:
  - `isNullReturn`
  - `isUndefinedReturn`
  - `isOptionSome`
  - `isVoidReturningFunction`
- Refactored 7 rules to use shared utilities:
  - `prefer-get-or-null` (-38% code)
  - `prefer-get-or-undefined` (-34% code)
  - `prefer-as-some` (-32% code)
  - `prefer-as-some-error` (-30% code)
  - `prefer-zip-left`
  - `prefer-zip-right`
  - `prefer-ignore`

## Benefits

- **DRY**: No duplicate method call checking logic
- **Maintainability**: Changes to common patterns only need to be made once
- **Consistency**: All rules use the same validation logic
- **Readability**: Rules are more concise

## Test plan

- [x] All existing tests pass
- [x] `turbo lint` passes
- [x] `turbo all` passes
- [x] No functional changes to rule behavior