### PR TITLE
fix(config): add mise tools to turbo global dependencies and pin versions

### DIFF
--- a/.changeset/fix-turbo-cache-invalidation.md
+++ b/.changeset/fix-turbo-cache-invalidation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix Turbo cache invalidation when tool versions change. Turbo will now correctly invalidate all task caches when Bun or other mise-managed tools are upgraded, preventing stale cached results from being used with incompatible tool versions.

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 bun = "1.2.23"
-gitleaks = "latest"
+gitleaks = "8.27.0"
 
 [env]
 _.path = ["./node_modules/.bin"]

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@effect/language-service": "0.43.0",
     "@effect/platform": "0.92.1",
     "@effect/platform-bun": "0.81.1",
-    "@types/bun": "latest",
+    "@types/bun": "1.2.23",
     "@typescript-eslint/eslint-plugin": "8.45.0",
     "@typescript-eslint/parser": "8.45.0",
     "dependency-cruiser": "17.0.2",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": [".mise.toml", ".tool-versions"],
   "tasks": {
     "all": {
       "dependsOn": ["ci"]


### PR DESCRIPTION
## Summary
Fixes turbo cache invalidation when tool versions change.

## Changes
- Added `.mise.toml` and `.tool-versions` to Turbo's `globalDependencies`
- Pinned `gitleaks` from "latest" to 8.27.0
- Pinned `@types/bun` from "latest" to 1.2.23

## Why
Without this fix, Turbo caches typecheck/build results based only on source files, ignoring tool version changes. This caused PR checks to pass using stale cached results even when the new tool version would produce different (failing) results.

Now when mise-managed tools are upgraded, Turbo will correctly invalidate all task caches.

## Test Plan
- [x] All checks pass with the changes
- [x] Cache invalidation verified with turbo dry-run showing new hashes