### PR TITLE
chore: configure Effect language service for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ build/
 # IDE
 .idea/
 .vscode/
+!.vscode/settings.json
+!.vscode/extensions.json
 *.swp
 *.swo
 *~

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,12 @@
     "exactOptionalPropertyTypes": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   },
   "exclude": ["node_modules", "dist", "lib"]
 }


### PR DESCRIPTION
## Summary

Enables Effect's TypeScript language service plugin to provide enhanced IDE support for developers working with Effect code.

## Changes

- **tsconfig.json**: Added `@effect/language-service` plugin configuration
- **.vscode/settings.json**: Configured VSCode to use workspace TypeScript version (required for language service plugins)
- **.vscode/extensions.json**: Added ESLint and Prettier extension recommendations
- **.gitignore**: Updated to allow VSCode settings to be committed for consistent team setup

## Benefits

The Effect language service provides:
- **Better type inference**: More accurate type information for Effect pipelines
- **Enhanced refactorings**: Effect-specific code transformations
- **Improved diagnostics**: Better error messages for common Effect patterns

## Developer Setup

After merging, developers should:
1. Accept VSCode prompt "Allow workspace version of TypeScript?"
2. Reload VSCode window
3. The language service will automatically provide enhanced Effect support

## Notes

- This is a development tooling change only - no changeset required
- Does not affect build output or published packages
- Language service works in IDE only, not in tsc compilation