### PR TITLE
refactor: introduce EventStreamPosition type throughout codebase

### DIFF
--- a/.changeset/refactor-event-stream-position.md
+++ b/.changeset/refactor-event-stream-position.md
@@ -1,0 +1,24 @@
+---
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+---
+
+Refactor to use `EventStreamPosition` type throughout the codebase instead of separate `streamId` and `eventNumber` parameters. This change improves type safety and API consistency by consolidating stream position information into a single, well-defined type.
+
+**Breaking changes:**
+
+- `EventStreamTracker.processEvent` now accepts `position: EventStreamPosition` instead of separate `streamId` and `eventNumber` parameters
+- `SubscriptionManagerService.publishToAllEvents` now accepts `position: EventStreamPosition` instead of separate `streamId` and `eventNumber` parameters
+- Internal subscription types now use `{ position: EventStreamPosition; event: string }` instead of `{ streamId: EventStreamId; eventNumber: number; event: string }`
+
+**Migration guide:**
+Replace separate streamId/eventNumber parameters with EventStreamPosition:
+
+```typescript
+// Before
+tracker.processEvent(streamId, eventNumber, event);
+subscriptionManager.publishToAllEvents(streamId, eventNumber, event);
+
+// After
+tracker.processEvent({ streamId, eventNumber }, event);
+subscriptionManager.publishToAllEvents({ streamId, eventNumber }, event);
+```

--- a/packages/eventsourcing-store-postgres/README.md
+++ b/packages/eventsourcing-store-postgres/README.md
@@ -290,8 +290,7 @@ const processEventsWithTracking = (
   eventStore: EventStore<MyEvent>,
   tracker: {
     readonly processEvent: <T>(
-      streamId: typeof toStreamId extends (id: string) => Effect.Effect<infer R> ? R : never,
-      eventNumber: number,
+      position: EventStreamPosition,
       event: T
     ) => Effect.Effect<Option.Option<T>>;
   }
@@ -417,8 +416,7 @@ const buildProjectionWithCheckpoints = (
   eventStore: EventStore<MyEvent>,
   tracker: {
     readonly processEvent: <T>(
-      streamId: typeof toStreamId extends (id: string) => Effect.Effect<infer R> ? R : never,
-      eventNumber: number,
+      position: EventStreamPosition,
       event: T
     ) => Effect.Effect<Option.Option<T>>;
   }


### PR DESCRIPTION
## Summary

Refactors the codebase to use the `EventStreamPosition` type throughout instead of passing separate `streamId` and `eventNumber` parameters. This improves type safety and API consistency by consolidating stream position information into a single, well-defined type.

## Changes

- **SubscriptionManager**: Updated `publishToAllEvents` to accept `EventStreamPosition` instead of separate parameters
- **EventStreamTracker**: Updated `processEvent` to accept `EventStreamPosition` 
- **Internal types**: Changed subscription types from `{ streamId, eventNumber, event }` to `{ position: EventStreamPosition, event }`
- **Documentation**: Updated README examples to reflect new API

## Breaking Changes

This is a breaking change for:
- `EventStreamTracker.processEvent(position, event)` - previously `(streamId, eventNumber, event)`
- `SubscriptionManagerService.publishToAllEvents(position, event)` - previously `(streamId, eventNumber, event)`

## Migration

```typescript
// Before
tracker.processEvent(streamId, eventNumber, event);
subscriptionManager.publishToAllEvents(streamId, eventNumber, event);

// After
tracker.processEvent({ streamId, eventNumber }, event);
subscriptionManager.publishToAllEvents({ streamId, eventNumber }, event);
```

## Testing

- ✅ All tests passing
- ✅ Documentation examples validated
- ✅ Changeset created

Closes hp-9