### PR TITLE
chore: widen @effect/platform peer dependency range

### DIFF
--- a/.changeset/widen-peer-deps.md
+++ b/.changeset/widen-peer-deps.md
@@ -1,0 +1,10 @@
+---
+'@codeforbreakfast/eventsourcing-store': patch
+'@codeforbreakfast/eventsourcing-store-filesystem': patch
+'@codeforbreakfast/eventsourcing-store-inmemory': patch
+'@codeforbreakfast/eventsourcing-store-postgres': patch
+---
+
+Widen `@effect/platform` peer dependency range from explicit minor versions to `>=0.90.0 <1.0.0`.
+
+This makes the packages more consumer-friendly by automatically supporting new Effect platform releases without requiring a library update, while still maintaining compatibility with versions 0.90.0 and above.

--- a/.changeset/widen-peer-deps.md
+++ b/.changeset/widen-peer-deps.md
@@ -3,6 +3,12 @@
 '@codeforbreakfast/eventsourcing-store-filesystem': patch
 '@codeforbreakfast/eventsourcing-store-inmemory': patch
 '@codeforbreakfast/eventsourcing-store-postgres': patch
+'@codeforbreakfast/eventsourcing-protocol': patch
+'@codeforbreakfast/eventsourcing-server': patch
+'@codeforbreakfast/eventsourcing-aggregates': patch
+'@codeforbreakfast/eventsourcing-commands': patch
+'@codeforbreakfast/eventsourcing-projections': patch
+'@codeforbreakfast/eventsourcing-testing-contracts': patch
 ---
 
 Widen `@effect/platform` peer dependency range from explicit minor versions to `>=0.90.0 <1.0.0`.

--- a/.changeset/widen-peer-deps.md
+++ b/.changeset/widen-peer-deps.md
@@ -9,6 +9,10 @@
 '@codeforbreakfast/eventsourcing-commands': patch
 '@codeforbreakfast/eventsourcing-projections': patch
 '@codeforbreakfast/eventsourcing-testing-contracts': patch
+'@codeforbreakfast/eventsourcing-transport': patch
+'@codeforbreakfast/eventsourcing-transport-inmemory': patch
+'@codeforbreakfast/eventsourcing-transport-websocket': patch
+'@codeforbreakfast/eventsourcing-websocket': patch
 ---
 
 Widen `@effect/platform` peer dependency range from explicit minor versions to `>=0.90.0 <1.0.0`.

--- a/packages/eventsourcing-store-filesystem/package.json
+++ b/packages/eventsourcing-store-filesystem/package.json
@@ -60,7 +60,7 @@
   "homepage": "https://github.com/codeforbreakfast/eventsourcing#readme",
   "peerDependencies": {
     "effect": "^3.17.0",
-    "@effect/platform": "^0.90.0 || ^0.91.0 || ^0.92.0 || ^0.93.0"
+    "@effect/platform": ">=0.90.0 <1.0.0"
   },
   "dependencies": {
     "@codeforbreakfast/eventsourcing-store": "workspace:*"

--- a/packages/eventsourcing-store-inmemory/package.json
+++ b/packages/eventsourcing-store-inmemory/package.json
@@ -60,7 +60,7 @@
   "homepage": "https://github.com/codeforbreakfast/eventsourcing#readme",
   "peerDependencies": {
     "effect": "^3.17.0",
-    "@effect/platform": "^0.90.0 || ^0.91.0 || ^0.92.0 || ^0.93.0"
+    "@effect/platform": ">=0.90.0 <1.0.0"
   },
   "dependencies": {
     "@codeforbreakfast/eventsourcing-store": "workspace:*"

--- a/packages/eventsourcing-store-postgres/package.json
+++ b/packages/eventsourcing-store-postgres/package.json
@@ -63,7 +63,7 @@
   "homepage": "https://github.com/codeforbreakfast/eventsourcing#readme",
   "peerDependencies": {
     "effect": "^3.17.0",
-    "@effect/platform": "^0.90.0 || ^0.91.0 || ^0.92.0 || ^0.93.0"
+    "@effect/platform": ">=0.90.0 <1.0.0"
   },
   "dependencies": {
     "@codeforbreakfast/eventsourcing-store": "workspace:*",

--- a/packages/eventsourcing-store/package.json
+++ b/packages/eventsourcing-store/package.json
@@ -61,7 +61,7 @@
   "homepage": "https://github.com/codeforbreakfast/eventsourcing#readme",
   "peerDependencies": {
     "effect": "^3.17.0",
-    "@effect/platform": "^0.90.0 || ^0.91.0 || ^0.92.0 || ^0.93.0"
+    "@effect/platform": ">=0.90.0 <1.0.0"
   },
   "dependencies": {
     "type-fest": "5.2.0"


### PR DESCRIPTION
## Summary
- Change `@effect/platform` peer dependency from explicit minors (`^0.90.0 || ^0.91.0 || ^0.92.0 || ^0.93.0`) to a wider range (`>=0.90.0 <1.0.0`)

## Why
The previous approach required a library release every time Effect released a new minor version of `@effect/platform`. Since we're tracking Effect closely with Renovate and have good test coverage, the wider range is:
- More consumer-friendly (no need to wait for our release)
- Less maintenance overhead
- Still safe (bounded by <1.0.0)

## Test plan
- [x] `turbo all` passes (excluding postgres tests which need a database)
- [x] Changeset created for affected packages